### PR TITLE
Fixes for lights, fans, and contact sensors in home assistant

### DIFF
--- a/hass/configurations.js
+++ b/hass/configurations.js
@@ -27,8 +27,8 @@ module.exports = {
     type: 'binary_sensor',
     object_id: 'contact',
     discovery_payload: {
-      payload_on: false,
-      payload_off: true,
+      payload_on: true,
+      payload_off: false,
       value_template: '{{ value_json.value }}',
       device_class: 'door'
     }

--- a/hass/configurations.js
+++ b/hass/configurations.js
@@ -276,11 +276,11 @@ module.exports = {
     object_id: 'dimmer',
     discovery_payload: {
       schema: 'template',
-      brightness_template: '{{ value_json.value }}',
+      brightness_template: '{{ (value_json.value / 99 * 255) | round(0) }}',
       state_topic: true,
       state_template: '{{ "off" if value_json.value == 0 else "on" }}',
       command_topic: true,
-      command_on_template: '{{ brightness if brightness is defined else 255 }}',
+      command_on_template: '{{ ((brightness / 255 * 99) | round(0)) if brightness is defined else 255 }}',
       command_off_template: '0'
     }
   },

--- a/hass/devices.js
+++ b/hass/devices.js
@@ -15,8 +15,8 @@ var FAN_DIMMER = {
     payload_medium_speed: 50,
     payload_high_speed: 99,
     payload_off: 0,
-    payload_on: 99,
-    state_value_template: "{% if (value_json.value | int) == 0 %} 0 {% else %} 99 {% endif %}",
+    payload_on: 255,
+    state_value_template: "{% if (value_json.value | int) == 0 %} 0 {% else %} 255 {% endif %}",
     speed_value_template: "{% if (value_json.value | int) == 25 %}  24  {% elif (value_json.value | int) == 51 %} 50 {% elif (value_json.value | int) == 99 %} 99 {% else %}  0  {% endif %}"
   }
 }


### PR DESCRIPTION
The device payload or lights has been changed and should work for all zwave lights. Lights now will turn on to their previous state if a brightness is not specified.

The fan payload for the GE/Jasco fans is now fixed so that the fan does not always turn on "high" by default. It will turn on to its previous state by default.