### PR TITLE
[fix] Disable z-wave node polling if polling is not set in settings

### DIFF
--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -196,8 +196,13 @@ function onNodeStatus (node) {
         if (!this.zwave.client.isPolled(v)) {
           this.zwave.callApi('enablePoll', v, values[i].pollIntensity || 1)
         }
-      } else if (values[i].verifyChanges) {
-        this.zwave.callApi('setChangeVerified', v, true)
+      } else {
+        if(this.zwave.client(isPolled(v))) {
+          this.zwave.callApi('disablePoll', v)
+        }
+        if (values[i].verifyChanges) {
+          this.zwave.callApi('setChangeVerified', v, true)
+        }
       }
     }
   }


### PR DESCRIPTION
Currently, it is not possible to disable node polling once that it has been enabled. This PR fixes that.