### PR TITLE
Add Eurotronic Sprit Z-Wave Plus as custom component

### DIFF
--- a/hass/devices.js
+++ b/hass/devices.js
@@ -21,6 +21,28 @@ var FAN_DIMMER = {
   }
 }
 
+// Eurotronic Spirit Z-Wave Plus Thermostat
+var SPIRIT_ZWAVE_PLUS =     {
+  type: 'climate',
+  object_id: 'thermostat',
+  values: ['64-1-0', '49-1-1', '67-1-1', '67-1-11'],
+  mode_map: { 'off': 'Off', 'heat': 'Heat', 'cool': 'Heat Eco' },
+  setpoint_topic: { 'Heat': '67-1-1', 'Heat Eco': '67-1-11' },
+  default_setpoint: '67-1-1',
+  discovery_payload: {
+    min_temp: 8,
+    max_temp: 28,
+    modes: ['off', 'heat', 'cool'],
+    mode_state_topic: '64-1-0',
+    mode_command_topic: true,
+    current_temperature_topic: '49-1-1',
+    current_temperature_template: '{{ value_json.value }}',
+    temperature_state_template: '{{ value_json.value }}',
+    temperature_command_topic: true
+  }
+}
+
+
 var COVER = {
   type: 'cover',
   object_id: 'position',
@@ -60,5 +82,7 @@ module.exports = {
     }
   ],
   '99-12340-18756': [FAN_DIMMER], // GE 1724 Dimmer
-  '99-12593-18756': [FAN_DIMMER] // GE 1724 Dimmer
+  '99-12593-18756': [FAN_DIMMER], // GE 1724 Dimmer
+  '328-1-3': [SPIRIT_ZWAVE_PLUS],
+  '328-3-3': [SPIRIT_ZWAVE_PLUS],
 }


### PR DESCRIPTION
Added Home Assistant support for [Eurotronic Spirit Z-Wave Plus](https://eurotronic.org/produkte/z-wave-heizkoerperthermostat/spirit-z-wave-plus/) thermostat via custom component.