### PR TITLE
Dimmers turn on to previous brightness by default

### DIFF
--- a/hass/configurations.js
+++ b/hass/configurations.js
@@ -323,7 +323,7 @@ module.exports = {
       state_topic: true,
       state_template: '{{ "off" if value_json.value == 0 else "on" }}',
       command_topic: true,
-      command_on_template: '{{ ((brightness / 255 * 99) | round(0)) if brightness is defined else 99 }}',
+      command_on_template: '{{ ((brightness / 255 * 99) | round(0)) if brightness is defined else 255 }}',
       command_off_template: '0'
     }
   },


### PR DESCRIPTION
This reverts the code in #125 so that dimmers can turn on to their previous brightness.