### PR TITLE
Make it possible for homeassistant to recognize thermostat valves without modes

### DIFF
--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -588,15 +588,21 @@ Gateway.prototype.discoverDevice = function (node, hassDevice) {
 
         var mode = node.values[payload.mode_state_topic]
         var currTemp = node.values[payload.current_temperature_topic]
-        var setId = hassDevice.setpoint_topic && hassDevice.setpoint_topic[mode.value] ? hassDevice.setpoint_topic[mode.value] : hassDevice.default_setpoint
+        var setId;
+        if(mode !== undefined) {
+          setId = hassDevice.setpoint_topic && hassDevice.setpoint_topic[mode.value] ? hassDevice.setpoint_topic[mode.value] : hassDevice.default_setpoint
+        }
+        else {
+          setId = hassDevice.default_setpoint;
+        }
         var setpoint = node.values[setId]
-
         var map = getMappedValues(mode, hassDevice.mode_map, this.config.integerList)
 
-        payload.mode_state_template = `{% set values = ${JSON.stringify(map.map)} %} {{ ${map.check} }}`
-
-        payload.mode_state_topic = this.mqtt.getTopic(this.valueTopic(node, mode))
-        payload.mode_command_topic = payload.mode_state_topic + '/set'
+        if(mode !== undefined) {
+          payload.mode_state_template = `{% set values = ${JSON.stringify(map.map)} %} {{ ${map.check} }}`
+          payload.mode_state_topic = this.mqtt.getTopic(this.valueTopic(node, mode))
+          payload.mode_command_topic = payload.mode_state_topic + '/set'
+        }
         payload.current_temperature_topic = this.mqtt.getTopic(this.valueTopic(node, currTemp))
         payload.temperature_state_topic = this.mqtt.getTopic(this.valueTopic(node, setpoint))
         payload.temperature_command_topic = payload.temperature_state_topic + '/set'

--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -591,6 +591,10 @@ Gateway.prototype.discoverDevice = function (node, hassDevice) {
         var setId;
         if(mode !== undefined) {
           setId = hassDevice.setpoint_topic && hassDevice.setpoint_topic[mode.value] ? hassDevice.setpoint_topic[mode.value] : hassDevice.default_setpoint
+          //only setup modes if a state topic was defined
+          payload.mode_state_template = `{% set values = ${JSON.stringify(map.map)} %} {{ ${map.check} }}`
+          payload.mode_state_topic = this.mqtt.getTopic(this.valueTopic(node, mode))
+          payload.mode_command_topic = payload.mode_state_topic + '/set'
         }
         else {
           setId = hassDevice.default_setpoint;
@@ -598,11 +602,6 @@ Gateway.prototype.discoverDevice = function (node, hassDevice) {
         var setpoint = node.values[setId]
         var map = getMappedValues(mode, hassDevice.mode_map, this.config.integerList)
 
-        if(mode !== undefined) {
-          payload.mode_state_template = `{% set values = ${JSON.stringify(map.map)} %} {{ ${map.check} }}`
-          payload.mode_state_topic = this.mqtt.getTopic(this.valueTopic(node, mode))
-          payload.mode_command_topic = payload.mode_state_topic + '/set'
-        }
         payload.current_temperature_topic = this.mqtt.getTopic(this.valueTopic(node, currTemp))
         payload.temperature_state_topic = this.mqtt.getTopic(this.valueTopic(node, setpoint))
         payload.temperature_command_topic = payload.temperature_state_topic + '/set'


### PR DESCRIPTION
Currently I have several rebranded Danfoss LC13's.
These thermostat valves do not support the setting of modes. 
Therefore, I'm unable to define the thermostats in the hass/devices.js as a thermostat.
Since, the current way the code is setup, it isn't possible to add thermostats without modes.
This pull request is a suggestion which would make it possible to add thermostat devices without modes to home assistant.

Adding HVAC (thermostat) devices to homeassistant without modes is possible: https://www.home-assistant.io/integrations/climate.mqtt/ . (The documentation of home assistant defines the mode values as optional.)

Currently, I've tested these changes with my thermostat devices and they now show up in home assistant as thermostats (HVAC's).

Note1: For this device to be recognized by openzwave as an LC13 danfoss valve  I had to edit the manufacturer_specific.xml file in a local copy of the repo: https://github.com/OpenZWave/open-zwave/blob/master/config/manufacturer_specific.xml.

Note2: I've also prepared device.js changes in my local repo copy of zwave2mqtt to support the valve if non-mode thermostat support is added. (These changes will be submitted in another MR if non-mode support is added).

Note3: The test setup in homeassistant consists of an clone of the zwave2mqtt hassio addons repo with a modified Dockerfile that pulls my versions of zwave2mqtt and openzwave. So I could test whether my changes have the desired effect for non-mode thermostat devices.


JSON data of my thermostat valve:
```json
{
   "node_id":8,
   "device_id":"2-380-5",
   "manufacturer":"Danfoss",
   "manufacturerid":"0x0002",
   "product":"Z Thermostat",
   "producttype":"0x0005",
   "productid":"0x017c",
   "type":"Setpoint Thermostat",
   "values":{
      "134-1-0":{
         "value_id":"8-134-1-0",
         "node_id":8,
         "class_id":134,
         "type":"string",
         "genre":"system",
         "instance":1,
         "index":0,
         "label":"Library Version",
         "units":"",
         "help":"",
         "read_only":true,
         "write_only":false,
         "min":0,
         "max":0,
         "is_polled":false,
         "value":"6"
      },
      "134-1-1":{
         "value_id":"8-134-1-1",
         "node_id":8,
         "class_id":134,
         "type":"string",
         "genre":"system",
         "instance":1,
         "index":1,
         "label":"Protocol Version",
         "units":"",
         "help":"",
         "read_only":true,
         "write_only":false,
         "min":0,
         "max":0,
         "is_polled":false,
         "value":"3.67"
      },
      "134-1-2":{
         "value_id":"8-134-1-2",
         "node_id":8,
         "class_id":134,
         "type":"string",
         "genre":"system",
         "instance":1,
         "index":2,
         "label":"Application Version",
         "units":"",
         "help":"",
         "read_only":true,
         "write_only":false,
         "min":0,
         "max":0,
         "is_polled":false,
         "value":"9.00"
      },
      "132-1-0":{
         "value_id":"8-132-1-0",
         "node_id":8,
         "class_id":132,
         "type":"int",
         "genre":"system",
         "instance":1,
         "index":0,
         "label":"Wake-up Interval",
         "units":"Seconds",
         "help":"",
         "read_only":false,
         "write_only":false,
         "min":-2147483648,
         "max":2147483647,
         "is_polled":false,
         "value":300
      },
      "128-1-0":{
         "value_id":"8-128-1-0",
         "node_id":8,
         "class_id":128,
         "type":"byte",
         "genre":"user",
         "instance":1,
         "index":0,
         "label":"Battery Level",
         "units":"%",
         "help":"",
         "read_only":true,
         "write_only":false,
         "min":0,
         "max":255,
         "is_polled":false,
         "value":40
      },
      "70-1-1":{
         "value_id":"8-70-1-1",
         "node_id":8,
         "class_id":70,
         "type":"schedule",
         "genre":"user",
         "instance":1,
         "index":1,
         "label":"Monday",
         "units":"",
         "help":"",
         "read_only":false,
         "write_only":false,
         "min":0,
         "max":0,
         "is_polled":false
      },
      "70-1-2":{
         "value_id":"8-70-1-2",
         "node_id":8,
         "class_id":70,
         "type":"schedule",
         "genre":"user",
         "instance":1,
         "index":2,
         "label":"Tuesday",
         "units":"",
         "help":"",
         "read_only":false,
         "write_only":false,
         "min":0,
         "max":0,
         "is_polled":false
      },
      "70-1-3":{
         "value_id":"8-70-1-3",
         "node_id":8,
         "class_id":70,
         "type":"schedule",
         "genre":"user",
         "instance":1,
         "index":3,
         "label":"Wednesday",
         "units":"",
         "help":"",
         "read_only":false,
         "write_only":false,
         "min":0,
         "max":0,
         "is_polled":false
      },
      "70-1-4":{
         "value_id":"8-70-1-4",
         "node_id":8,
         "class_id":70,
         "type":"schedule",
         "genre":"user",
         "instance":1,
         "index":4,
         "label":"Thursday",
         "units":"",
         "help":"",
         "read_only":false,
         "write_only":false,
         "min":0,
         "max":0,
         "is_polled":false
      },
      "70-1-5":{
         "value_id":"8-70-1-5",
         "node_id":8,
         "class_id":70,
         "type":"schedule",
         "genre":"user",
         "instance":1,
         "index":5,
         "label":"Friday",
         "units":"",
         "help":"",
         "read_only":false,
         "write_only":false,
         "min":0,
         "max":0,
         "is_polled":false
      },
      "70-1-6":{
         "value_id":"8-70-1-6",
         "node_id":8,
         "class_id":70,
         "type":"schedule",
         "genre":"user",
         "instance":1,
         "index":6,
         "label":"Saturday",
         "units":"",
         "help":"",
         "read_only":false,
         "write_only":false,
         "min":0,
         "max":0,
         "is_polled":false
      },
      "70-1-7":{
         "value_id":"8-70-1-7",
         "node_id":8,
         "class_id":70,
         "type":"schedule",
         "genre":"user",
         "instance":1,
         "index":7,
         "label":"Sunday",
         "units":"",
         "help":"",
         "read_only":false,
         "write_only":false,
         "min":0,
         "max":0,
         "is_polled":false
      },
      "70-1-8":{
         "value_id":"8-70-1-8",
         "node_id":8,
         "class_id":70,
         "type":"list",
         "genre":"user",
         "instance":1,
         "index":8,
         "label":"Override State",
         "units":"",
         "help":"",
         "read_only":false,
         "write_only":false,
         "min":0,
         "max":0,
         "is_polled":false,
         "values":[
            "None",
            "Temporary",
            "Permanent"
         ],
         "value":"None"
      },
      "70-1-9":{
         "value_id":"8-70-1-9",
         "node_id":8,
         "class_id":70,
         "type":"byte",
         "genre":"user",
         "instance":1,
         "index":9,
         "label":"Override Setback",
         "units":"",
         "help":"",
         "read_only":false,
         "write_only":false,
         "min":0,
         "max":255,
         "is_polled":false,
         "value":127
      },
      "129-1-0":{
         "value_id":"8-129-1-0",
         "node_id":8,
         "class_id":129,
         "type":"list",
         "genre":"user",
         "instance":1,
         "index":0,
         "label":"Day",
         "units":"",
         "help":"",
         "read_only":false,
         "write_only":false,
         "min":0,
         "max":0,
         "is_polled":false,
         "values":[
            "Monday",
            "Tuesday",
            "Wednesday",
            "Thursday",
            "Friday",
            "Saturday",
            "Sunday"
         ],
         "value":"Monday"
      },
      "129-1-1":{
         "value_id":"8-129-1-1",
         "node_id":8,
         "class_id":129,
         "type":"byte",
         "genre":"user",
         "instance":1,
         "index":1,
         "label":"Hour",
         "units":"",
         "help":"",
         "read_only":false,
         "write_only":false,
         "min":0,
         "max":255,
         "is_polled":false,
         "value":13
      },
      "129-1-2":{
         "value_id":"8-129-1-2",
         "node_id":8,
         "class_id":129,
         "type":"byte",
         "genre":"user",
         "instance":1,
         "index":2,
         "label":"Minute",
         "units":"",
         "help":"",
         "read_only":false,
         "write_only":false,
         "min":0,
         "max":255,
         "is_polled":false,
         "value":2
      },
      "117-1-0":{
         "value_id":"8-117-1-0",
         "node_id":8,
         "class_id":117,
         "type":"list",
         "genre":"system",
         "instance":1,
         "index":0,
         "label":"Protection",
         "units":"",
         "help":"",
         "read_only":false,
         "write_only":false,
         "min":0,
         "max":0,
         "is_polled":false,
         "values":[
            "Unprotected",
            "Protection by Sequence",
            "No Operation Possible"
         ],
         "value":"Unprotected"
      },
      "132-1-1":{
         "value_id":"8-132-1-1",
         "node_id":8,
         "class_id":132,
         "type":"int",
         "genre":"system",
         "instance":1,
         "index":1,
         "label":"Minimum Wake-up Interval",
         "units":"Seconds",
         "help":"",
         "read_only":true,
         "write_only":false,
         "min":-2147483648,
         "max":2147483647,
         "is_polled":false,
         "value":60
      },
      "132-1-2":{
         "value_id":"8-132-1-2",
         "node_id":8,
         "class_id":132,
         "type":"int",
         "genre":"system",
         "instance":1,
         "index":2,
         "label":"Maximum Wake-up Interval",
         "units":"Seconds",
         "help":"",
         "read_only":true,
         "write_only":false,
         "min":-2147483648,
         "max":2147483647,
         "is_polled":false,
         "value":1800
      },
      "132-1-3":{
         "value_id":"8-132-1-3",
         "node_id":8,
         "class_id":132,
         "type":"int",
         "genre":"system",
         "instance":1,
         "index":3,
         "label":"Default Wake-up Interval",
         "units":"Seconds",
         "help":"",
         "read_only":true,
         "write_only":false,
         "min":-2147483648,
         "max":2147483647,
         "is_polled":false,
         "value":300
      },
      "132-1-4":{
         "value_id":"8-132-1-4",
         "node_id":8,
         "class_id":132,
         "type":"int",
         "genre":"system",
         "instance":1,
         "index":4,
         "label":"Wake-up Interval Step",
         "units":"Seconds",
         "help":"",
         "read_only":true,
         "write_only":false,
         "min":-2147483648,
         "max":2147483647,
         "is_polled":false,
         "value":60
      },
      "49-1-1":{
         "value_id":"8-49-1-1",
         "node_id":8,
         "class_id":49,
         "type":"decimal",
         "genre":"user",
         "instance":1,
         "index":1,
         "label":"Temperature",
         "units":"C",
         "help":"",
         "read_only":true,
         "write_only":false,
         "min":0,
         "max":0,
         "is_polled":false,
         "value":17.41
      },
      "67-1-1":{
         "value_id":"8-67-1-1",
         "node_id":8,
         "class_id":67,
         "type":"decimal",
         "genre":"user",
         "instance":1,
         "index":1,
         "label":"Heating 1",
         "units":"C",
         "help":"",
         "read_only":false,
         "write_only":false,
         "min":0,
         "max":0,
         "is_polled":false,
         "value":16
      }
   },
   "groups":[

   ],
   "neighborns":[

   ],
   "ready":true,
   "available":true,
   "hassDevices":{

   },
   "failed":false,
   "status":"Alive",
   "version":"Unknown"
}
```