### PR TITLE
Fixed crash when components are set to {}

### DIFF
--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -553,25 +553,29 @@ Gateway.prototype.valueTopic = function (node, valueId, returnObject) {
   }
 }
 
-Gateway.prototype.publishDiscovery = function (hassDevice, nodeId, deleteDevice, update) {
-  // set values as discovered
-  for (let k = 0; k < hassDevice.values.length; k++) {
-    this.discovered[nodeId + '-' + hassDevice.values[k]] = hassDevice
-  }
+Gateway.prototype.publishDiscovery = function (hassDevice, nodeId, deleteDevice, update) {  
+  try {
+    // set values as discovered
+    for (let k = 0; k < hassDevice.values.length; k++) {
+      this.discovered[nodeId + '-' + hassDevice.values[k]] = hassDevice
+    }
 
-  if (this.config.payloadType === 2) { // Payload is set to "Just Value"
-    var p = hassDevice.discovery_payload
-    for (const k in p) {
-      if (/_template\b/g.test(k)) {
-        p[k] = p[k].replace(/value_json.value/g, 'value')
+    if (this.config.payloadType === 2) { // Payload is set to "Just Value"
+      var p = hassDevice.discovery_payload
+      for (const k in p) {
+        if (/_template\b/g.test(k)) {
+          p[k] = p[k].replace(/value_json.value/g, 'value')
+        }
       }
     }
-  }
 
-  this.mqtt.publish(hassDevice.discoveryTopic, deleteDevice ? '' : hassDevice.discovery_payload, { qos: 0, retain: this.config.retainedDiscovery || false }, this.config.discoveryPrefix)
+    this.mqtt.publish(hassDevice.discoveryTopic, deleteDevice ? '' : hassDevice.discovery_payload, { qos: 0, retain: this.config.retainedDiscovery || false }, this.config.discoveryPrefix)
 
-  if (update) {
-    this.zwave.updateDevice(hassDevice, nodeId, deleteDevice)
+    if (update) {
+      this.zwave.updateDevice(hassDevice, nodeId, deleteDevice)
+    }
+  } catch (error) {
+    debug('Error while publishing node %d: %s', nodeId, error.message)
   }
 }
 


### PR DESCRIPTION
This should fix issue reported in #99 and #178. Might not be perfect, but definitely better than having Z2M crash without any good hint about the reason.