### PR TITLE
Spelling and consistency (no change in behavior)

### DIFF
--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -497,12 +497,12 @@ export default {
     },
     newName (val) {
       this.nameError = /["+*\s]+/g.test(val)
-        ? 'Remove " + * and blank space charaters'
+        ? 'Remove " + * and blank space characters'
         : null
     },
     newLoc (val) {
       this.locError = /["+*\s]+/g.test(val)
-        ? 'Remove " + * and blank space charaters'
+        ? 'Remove " + * and blank space characters'
         : null
     },
     selectedNode () {
@@ -633,7 +633,7 @@ export default {
           value: 'addNode'
         },
         {
-          text: 'Remove Node (exclusion)',
+          text: 'Remove node (exclusion)',
           value: 'removeNode'
         },
         {
@@ -718,7 +718,7 @@ export default {
       var self = this
       if (
         confirm(
-          'Attention: This will override all existing nodes names and location'
+          'Attention: This will override all existing nodes names and locations'
         )
       ) {
         self.$emit('import', 'json', function (err, data) {


### PR DESCRIPTION
"charaters" is a spelling error; it may still need commas -- Oxford, of course!  Additionally, slight inconsistency in uppercase/lowercase, and pluralism agreement.

There remains an outstanding oddity on multi instance association description.

Additionally, line 721 should be "nodes' names and locations", but since " ' " is the delimiter on the text string, I can't use it as an apostrophe.  Maybe "node names and locations" remains valid english.