### PR TITLE
Enable sending raw zwave data

### DIFF
--- a/lib/ZwaveClient.js
+++ b/lib/ZwaveClient.js
@@ -1126,8 +1126,14 @@ ZwaveClient.prototype.callApi = async function (apiName, ...args) {
           node.failed = this.client.hasNodeFailed(nodeid)
         }
       }
+     
       // Check if I need to call a zwave client function or a custom function
       var useCustom = typeof this[apiName] === 'function' && ((apiName.toLowerCase().includes('scene') && apiName.startsWith('_')) || apiName === '_setNodeName' || apiName === '_setNodeLocation' || apiName === 'refreshNeighborns')
+
+      //Send raw data expects a buffer as the fifth argument, which JSON does not support, so we convert an array of bytes into a buffer.
+      if(apiName === 'sendRawData') {
+        args[4] = Buffer.from(args[4]);
+      }
 
       if (useCustom) {
         result = await this[apiName](...args)


### PR DESCRIPTION
This patch allows using the api topic to send raw Z-Wave packets. This is extremely useful for devices like the EUROtronic SPIRITZ thermostat, which requires raw messages to use an external temperature source.

Note: This api is only available in very recent versions of OpenZWave.