### PR TITLE
Support dynamic reads of customDevices.json

### DIFF
--- a/build/webpack.dev.conf.js
+++ b/build/webpack.dev.conf.js
@@ -31,6 +31,7 @@ const devWebpackConfig = merge(baseWebpackConfig, {
     hot: true,
     contentBase: false, // since we use CopyWebpackPlugin.
     compress: true,
+    disableHostCheck: true,
     host: HOST || config.dev.host,
     port: PORT || config.dev.port,
     open: config.dev.autoOpenBrowser,

--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -2,7 +2,9 @@
 /* eslint-disable one-var */
 'use strict'
 
+const fs = require('fs')
 const reqlib = require('app-root-path').require
+const utils = reqlib('/lib/utils.js');
 const EventEmitter = require('events')
 const comandClass = reqlib('/lib/Constants.js').comandClass
 const debug = reqlib('/lib/debug')('Gateway')
@@ -11,25 +13,18 @@ const hassCfg = reqlib('/hass/configurations.js')
 const hassDevices = reqlib('/hass/devices.js')
 const version = reqlib('package.json').version
 
-debug.color = 2
+const CUSTOM_DEVICES = utils.joinPath(true, reqlib('config/app.js').storeDir, 'customDevices')
 
-try {
-  const storeDir = reqlib('config/app.js').storeDir
-  const customDevices = reqlib(storeDir + '/customDevices')
-  let i = 0
-  for (const d in customDevices) {
-    hassDevices[d] = customDevices[d]
-    i++
+// Continue supporting customDevices.js for now
+if (fs.existsSync(CUSTOM_DEVICES + '.js')) {
+  const devices = reqlib(CUSTOM_DEVICES + '.js')
+  for (const key in devices) {
+    hassDevices[key] = devices[key]
   }
-
-  debug('Loaded', i, 'custom hass devices configurations')
-} catch (error) {
-  if (error.message.indexOf('Cannot find module') >= 0) {
-    debug('No custom hass devices file found')
-  } else {
-    debug('Error while loading store/customDevices', error.message)
-  }
+  debug('Loaded', Object.keys(devices).length, 'custom js hass devices configurations')
 }
+
+debug.color = 2
 
 const NODE_PREFIX = 'nodeID_'
 // const GW_TYPES = ['valueID', 'named', 'manual']
@@ -62,6 +57,8 @@ function init (config, zwave, mqtt) {
   this.topicValues = {}
 
   this.discovered = {}
+
+  this.customDevicesLength = Object.keys(hassDevices).length
 
   if (mqtt) {
     mqtt.on('writeRequest', onWriteRequest.bind(this))
@@ -199,8 +196,6 @@ function onValueChanged (valueId, node, changed) {
 
 function onNodeStatus (node) {
   if (node.ready && this.config.hassDiscovery) {
-    var nodeDevices = hassDevices[node.device_id] || []
-
     for (const id in node.hassDevices) {
       if (node.hassDevices[id].persistent) {
         this.publishDiscovery(node.hassDevices[id], node.node_id)
@@ -208,9 +203,14 @@ function onNodeStatus (node) {
     }
 
     // discover node devices
-    for (let i = 0; i < nodeDevices.length; i++) {
-      this.discoverDevice(node, nodeDevices[i])
+    const allDevices = this.loadDevices()
+    const deviceKeys = Object.keys(allDevices)
+    if (deviceKeys.length !== this.customDevicesLength) {
+      this.customDevicesLength = deviceKeys.length
+      debug(`Loaded ${this.customDevicesLength} custom hass device configurations: ${deviceKeys.join(', ')}`)
     }
+    const nodeDevices = allDevices[node.device_id] || []
+    nodeDevices.forEach(device => this.discoverDevice(node, device))
 
     // discover node values (that are not part of a device)
     for (let id in node.values) {
@@ -990,6 +990,27 @@ Gateway.prototype.discoverValue = function (node, valueId) {
   } catch (error) {
     debug('Error while discovering value %s of node %d: %s', valueId.value_id, node.node_id, error.message)
   }
+}
+
+
+Gateway.prototype.loadDevices = function () {
+  try {
+    // Should probably use a cache and file stating to get mtime
+    // before reading the entire file again
+    const filepath = CUSTOM_DEVICES + '.json'
+    if (fs.existsSync(filepath)) {
+      const fileContent = fs.readFileSync(filepath)
+      const devices = JSON.parse(fileContent)
+      const keys = Object.keys(devices)
+      return {
+        ...hassDevices,
+        ...devices
+      }
+    }
+  } catch (error) {
+    debug('Error while loading store/customDevices', error.message)
+  }
+  return hassDevices
 }
 
 module.exports = Gateway


### PR DESCRIPTION
If you use a customDevices.json this will now be re-read on every node discovery instead of being read once when you start the server.
This makes it easier to build out z-wave networks without being forced into network scans due to restarts

Dynamic parsing of customDevices.js is not suported (would either require clearing require cache hack or evaling) but it is still read at startup to continue supporting it.

It also adds `disableHostCheck` for webpack dev-server to enable reaching it over something else than localhost when you set `HOST=0.0.0.0`