### PR TITLE
set sensor_home_security to index 7, sensor_access_control to 6

### DIFF
--- a/hass/configurations.js
+++ b/hass/configurations.js
@@ -132,25 +132,9 @@ module.exports = {
       value_template: '{{ value_json.value }}'
     }
   },
-  'sensor_alarm_level': {
+  'sensor_alarm': {
     type: 'sensor',
-    object_id: 'alarm_level',
-    discovery_payload: {
-      icon: 'mdi:alarm-light',
-      value_template: '{{ value_json.value }}'
-    }
-  },
-  'sensor_alarm_type': {
-    type: 'sensor',
-    object_id: 'alarm_type',
-    discovery_payload: {
-      icon: 'mdi:alarm-light',
-      value_template: '{{ value_json.value }}'
-    }
-  },
-  'sensor_alarm_burglar': {
-    type: 'sensor',
-    object_id: 'alarm_burglar',
+    object_id: 'alarm',
     discovery_payload: {
       icon: 'mdi:alarm-light',
       value_template: '{{ value_json.value }}'

--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -856,21 +856,40 @@ Gateway.prototype.discoverValue = function (node, valueId) {
       case 'sensor_alarm':
         cfg = copy(hassCfg.binary_sensor_alarm)
         break
+
       case 'alarm':
-
-        if (valueId.index < 256) {
-          cfg = 'sensor_alarm_burglar'
-        } else if (valueId.index === 512) {
-          cfg = 'sensor_alarm_type'
-        } else if (valueId.index === 513) {
-          cfg = 'sensor_alarm_level'
+        // https://github.com/OpenZWave/open-zwave/blob/4478eea26b0e1a29184df0515a8034757258ff88/cpp/src/ValueIDIndexesDefines.def#L1068
+        // https://github.com/OpenZWave/open-zwave/blob/05a096f75dddd27e3f8dc6af2afdb3cad3b4ebaa/config/Localization.xml#L7
+        let valueIndexAlarmTypeMap = {
+          1: 'smoke',
+          2: 'carbon_monoxide',
+          3: 'carbon_dioxide',
+          4: 'heat',
+          5: 'water',
+          6: 'access_control',
+          7: 'home_security',
+          8: 'power_management',
+          9: 'system',
+          10: 'emergency',
+          11: 'clock',
+          12: 'appliance',
+          13: 'home_health',
+          14: 'siren',
+          15: 'water_valve',
+          16: 'weather',
+          17: 'irrigation',
+          18: 'gas',
+          512: 'type',
+          513: 'level'
         }
+        let alarmType = valueIndexAlarmTypeMap[valueId.index]
+        if (!alarmType) return
 
-        if (cfg && hassCfg[cfg]) {
-          cfg = copy(hassCfg[cfg])
-        } else return
+        cfg = copy(hassCfg.sensor_alarm)
+        cfg.object_id += '_' + alarmType
 
         break
+
       case 'sensor_multilevel':
       case 'meter':
       case 'meter_pulse':


### PR DESCRIPTION
Not all alarm command class indeces below 256 are burglar according to https://github.com/OpenZWave/open-zwave/blob/4478eea26b0e1a29184df0515a8034757258ff88/cpp/src/ValueIDIndexesDefines.def#L1068

This PR sets sensor_home_security to index 7 and sensor_access_control to index 6.

Cheers,