### PR TITLE
refactor: sensor multilevel constants

### DIFF
--- a/hass/devices.js
+++ b/hass/devices.js
@@ -36,7 +36,7 @@ var SPIRIT_ZWAVE_PLUS = {
     mode_state_topic: '64-1-0',
     mode_command_topic: true,
     current_temperature_topic: '49-1-1',
-    temp_step: 0.5, 
+    temp_step: 0.5,
     current_temperature_template: '{{ value_json.value }}',
     temperature_state_template: '{{ value_json.value }}',
     temperature_command_topic: true

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -1,6 +1,6 @@
 module.exports = {
   meterType (index) { // https://github.com/OpenZWave/open-zwave/blob/0d94c9427bbd19e47457578bccc60b16c6679b49/cpp/src/command_classes/Meter.cpp#L74
-    var cfg = null
+    let cfg = null
     if (index >= 16 && index < 32) {
       cfg = 'sensor_gas'
     } else if (index < 48) {
@@ -13,7 +13,7 @@ module.exports = {
   alarmType (index) {
     // https://github.com/OpenZWave/open-zwave/blob/4478eea26b0e1a29184df0515a8034757258ff88/cpp/src/ValueIDIndexesDefines.def#L1068
     // https://github.com/OpenZWave/open-zwave/blob/05a096f75dddd27e3f8dc6af2afdb3cad3b4ebaa/config/Localization.xml#L7
-    var alarmMap = {
+    let alarmMap = {
       1: 'smoke',
       2: 'carbon_monoxide',
       3: 'carbon_dioxide',
@@ -32,6 +32,8 @@ module.exports = {
       16: 'weather',
       17: 'irrigation',
       18: 'gas',
+      256: 'previous_event_cleared',
+      257: 'alert_location',
       512: 'type',
       513: 'level'
     }
@@ -39,85 +41,144 @@ module.exports = {
     return alarmMap[index] || 'unknown_' + index
   },
   sensorType (index) { // https://github.com/OpenZWave/open-zwave/blob/0d94c9427bbd19e47457578bccc60b16c6679b49/config/SensorMultiLevelCCTypes.xml
-    switch (index) {
-      case 1:
-      case 11:
-      case 23:
-      case 24:
-      case 34:
-      case 62:
-      case 63:
-      case 64:
-      case 65:
-      case 72:
-      case 73:
-      case 74:
-      case 75:
-      case 76:
-      case 77:
-      case 80:
-        return 'sensor_temperature'
-      case 3:
-        return 'sensor_illuminance'
-      case 4:
-      case 15:
-      case 16:
-      case 28:
-      case 29:
-        return 'sensor_electricity'
-      case 5:
-      case 41:
-        return 'sensor_humidity'
-      case 6:
-      case 52:
-      case 53:
-      case 54:
-      case 8: // pressure
-      case 9: // pressure
-        return 'sensor_speed'
-      case 7:
-      case 21: // angle position
-        return 'sensor_direction'
-      case 10:
-      case 27: // uv index
-        return 'sensor_sun'
-      case 12: // rain rate
-      case 13: // tide level
-      case 19: // capacity
-      case 56:
-      case 57:
-        return 'sensor_water'
-      case 14:
-      case 46:
-      case 47:
-      case 48:
-      case 49:
-      case 51:
-      case 66:
-      case 67:
-      case 68:
-        return 'sensor_weight'
-      case 17:
-      case 40: // carbon monoxide
-      case 55:
-        return 'sensor_co2'
-      case 18:
-        return 'sensor_air'
-      case 22:
-        return 'sensor_frequency'
-      case 30:
-        return 'sensor_sound'
-      case 33:
-        return 'sensor_time'
-      case 44:
-      case 45:
-      case 50:
-      case 60:
-      case 69:
-        return 'sensor_heart'
-      default:
-        return null
+    let sensorMap = {
+      'sensor_temperature': {
+        1: 'air',
+        11: 'dew_point',
+        23: 'water',
+        24: 'soil',
+        34: 'target',
+        62: 'boiler_water',
+        63: 'domestic_hot_water',
+        64: 'outside',
+        65: 'exhaust',
+        72: 'return_air',
+        73: 'supply_air',
+        74: 'condenser_coil',
+        75: 'evaporator_coil',
+        76: 'liquid_line',
+        77: 'discharge_line',
+        80: 'defrost'
+      },
+      'sensor_illuminance': {
+        3: '' // illuminance
+      },
+      'sensor_electricity': {
+        4: 'power',
+        15: 'voltage',
+        16: 'current',
+        28: 'resistivity',
+        29: 'conductivity'
+      },
+      'sensor_humidity': {
+        5: 'air', // humidity
+        41: 'soil'
+      },
+      'sensor_speed': {
+        6: 'velocity', // ?
+        52: 'x_acceleration',
+        53: 'y_acceleration',
+        54: 'z_acceleration'
+      },
+      'sensor_direction': {
+        7: '', // direction
+        21: 'angle_position' // ?
+      },
+      'sensor_pressure': {
+        8: 'atmospheric',
+        9: 'barometric'
+      },
+      'sensor_sun': {
+        10: 'solar_radiation',
+        27: 'ultraviolet'
+      },
+      'sensor_water': {
+        12: 'rain_rate',
+        13: 'tide_level',
+        19: 'tank_capacity',
+        56: 'flow',
+        57: 'pressure' // should this be a pressure sensor instead?
+      },
+      'sensor_weight': {
+        14: '', // weight
+        46: 'muscle_mass',
+        47: 'bone_mass',
+        48: 'fat_mass',
+        49: 'total_body_water',
+        51: 'body_mass_index',
+        66: 'water_chlorine',
+        67: 'water_acidity',
+        68: 'water_oxidation_potential'
+      },
+      'sensor_co2': {
+        17: 'carbon_dioxide',
+        40: 'carbon_monoxide',
+        55: 'smoke_density'
+      },
+      'sensor_air': {
+        18: 'flow'
+      },
+      'sensor_frequency': {
+        22: 'rotation',
+        32: ''
+      },
+      'sensor_sound': {
+        30: 'loudness'
+      },
+      'sensor_time': {
+        33: '' // time
+      },
+      'sensor_heart': {
+        44: 'rate',
+        45: 'blood_pressure',
+        50: 'basic_metabolic_rate',
+        60: 'respiratory_rate',
+        69: 'lf_lh_ratio'
+      },
+      'sensor_generic': {
+        2: 'general_purpose',
+        20: 'distance',
+        25: 'seismic_intensity',
+        26: 'seismic_magnitude',
+        31: 'moisture',
+        35: 'particulate_matter_25',
+        36: 'formaldehyde',
+        37: 'radon_concentration',
+        38: 'methane_density',
+        39: 'volatile_organic_compound',
+        42: 'soil_reactivity',
+        43: 'soil_salinity',
+        58: 'rf_signal_strength',
+        59: 'particulate_matter',
+        61: 'relative_modulation',
+        70: 'motion_direction',
+        71: 'applied_force',
+        78: 'suction',
+        79: 'discharge',
+        81: 'ozone',
+        82: 'sulfur_dioxide',
+        83: 'nitrogen_dioxide',
+        84: 'ammonia',
+        85: 'lead',
+        86: 'particulate_matter'
+      }
     }
+
+    let sensorType = {
+      sensor: 'sensor_generic',
+      objectId: 'unknown_' + index
+    }
+
+    for (let sensor in sensorMap) {
+      let objectId = sensorMap[sensor][index]
+      if (objectId === undefined) continue // objectId can be an empty string
+
+      sensorType.sensor = sensor
+      sensorType.objectId = objectId
+      break
+    }
+
+    return sensorType
   },
   commandClass (cmd) {
     switch (cmd) {

--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -327,9 +327,9 @@ function onWriteRequest (parts, payload) {
 }
 
 /**
-* Checks if an operation is valid, it must exist and must contains
-* only numbers and operators
-*/
+ * Checks if an operation is valid, it must exist and must contains
+ * only numbers and operators
+ */
 function isValidOperation (op) {
   return op && !/[^0-9.()\-+*/,]/g.test(op)
 }
@@ -436,7 +436,7 @@ function getDiscoveryTopic (hassDevice, nodeName) {
 }
 
 /**
- * Calcolate the correct template string to use for modes templates
+ * Calculate the correct template string to use for modes templates
  * based on gateway settings and mapped mode values
  *
  * @param {Object} valueId Zwave ValueId object
@@ -461,9 +461,9 @@ function getMappedValues (valueId, modeMap, integerList, defaultValue) {
 }
 
 /**
-* Parse the value of the payload received from mqtt
-* based on the type of the payload and the gateway config
-*/
+ * Parse the value of the payload received from mqtt
+ * based on the type of the payload and the gateway config
+ */
 Gateway.prototype.parsePayload = function (payload, valueId, valueConf) {
   try {
     payload = payload.hasOwnProperty('value') ? payload.value : payload
@@ -868,12 +868,13 @@ Gateway.prototype.discoverValue = function (node, valueId) {
 
         // https://github.com/OpenZWave/open-zwave/blob/master/config/Localization.xml#L885
         if (type === 'sensor_multilevel') {
-          cfg = Constants.sensorType(valueId.index)
+          let sensorType = Constants.sensorType(valueId.index)
+          cfg = copy(hassCfg[sensorType.sensor])
+          if (sensorType.objectId) cfg.object_id += '_' + sensorType.objectId // objectId can be an empty string
         } else if (type === 'meter') { // https://github.com/OpenZWave/open-zwave/blob/master/config/Localization.xml#L680
           cfg = Constants.meterType(valueId.index)
+          cfg = cfg ? copy(hassCfg[cfg]) : copy(hassCfg.sensor_generic)
         }
-
-        cfg = cfg ? copy(hassCfg[cfg]) : copy(hassCfg.sensor_generic)
 
         if (valueId.units) {
           cfg.discovery_payload.unit_of_measurement = valueId.units


### PR DESCRIPTION
This refactors how we determine multilevel sensor types to be similar to how we do alarm sensors. It includes the names for the object ids.

@robertsLando there are some cases where the object id has the same name as the sensor type, so I kept it blank to avoid names like `direction_direction`. Let me know what you think.

Also, some sensors look like they belong to other types, but I didn't want to move them around just yet. For example, sensor 57 is under *sensor_water*, but it's a water pressure sensor, and maybe it should be under *sensor_pressure* instead..

Another thing to consider is in the future we may want to populate not just object ids but also units of measurement based on the constants.

It would be really great if instead of redefining things in the Constants.js if we could just read in the open-zwave xml files that it's based on and parse them to the correct attributes, i.e.: config/Localization.xml and config/SensorMultiLevelCCTypes.xml

Cheers,