### PR TITLE
Fix electricity meter named as water meter

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -36,14 +36,14 @@ module.exports = {
       33: 'ft3',
       34: 'gal',
       35: 'pulses',
-      48: 'kwh',
-      64: 'kwh'
+      48: 'kwh', // heating (electricity)
+      64: 'kwh' // cooling (electricity)
     }
 
     let cfg = null
     if (index >= 16 && index < 32) { // gas
       cfg = this.sensorType(55)
-    } else if (index < 48) { // water
+    } else if (index >= 32 && index < 48) { // water
       cfg = this.sensorType(12)
     } else { // electricity
       cfg = this.sensorType(4)


### PR DESCRIPTION
Electricity kwh meter got classified and named as a water meter instead as an electricity meter as it is supposed to be. sensor_water_kwh_meter instead of sensor_electricity_kwh_meter.