### PR TITLE
Add "remove failed node" command

### DIFF
--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -625,6 +625,10 @@ export default {
           value: 'hasNodeFailed'
         },
         {
+          text: 'Remove failed node',
+          value: 'removeFailedNode'
+        },
+        {
           text: 'Replace failed node',
           value: 'replaceFailedNode'
         },


### PR DESCRIPTION
Adding one more node command - removeFailedNode 

- this command can be used after a node is Dead or "Has node failed" been executed against node.
- This command can delete/remove permanently a node from the controller
 