### PR TITLE
Fix temperature sensor's unit of measurement for HomeAssistsant

### DIFF
--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -943,6 +943,9 @@ Gateway.prototype.discoverValue = function (node, valueId) {
 
         if (valueId.units) {
           cfg.discovery_payload.unit_of_measurement = valueId.units
+          if (['C', 'F'].indexOf(valueId.units.toUpperCase()) > -1) {
+            cfg.discovery_payload.unit_of_measurement = "°"+cfg.discovery_payload.unit_of_measurement.toUpperCase();
+          }
         }
 
         // check if there is a custom value configuration for this valueID


### PR DESCRIPTION
This fixes the unit of measurement for temperature sensors when being used in HomeAssistant's auto discovery feature. My sensors were throwing errors when being used inside of HomeAssistant. 

https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/const.py#L343
https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/util/temperature.py#L28