### PR TITLE
use fan_mode_map instead of mode_map for thermostat_fan_mode command class

### DIFF
--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -489,7 +489,7 @@ Gateway.prototype.parsePayload = function (payload, valueId, valueConf) {
 
     // Hass payload parsing
     if (this.discovered[valueId.value_id]) {
-      // parse payload for switchs
+      // parse payload for switches
       if ((valueId.type === 'bool' || this.discovered[valueId.value_id].object_id === 'rgb_dimmer') && typeof payload === 'string') {
         if (/\btrue\b|\bon\b|\block\b/gi.test(payload)) payload = true
         else if (/\bfalse\b|\boff\b|\bunlock\b/gi.test(payload)) payload = false
@@ -502,15 +502,20 @@ Gateway.prototype.parsePayload = function (payload, valueId, valueConf) {
 
       // map modes coming from hass
       if (valueId.type === 'list' && valueId.values.indexOf(payload) < 0) {
-        var hassDevice = this.discovered[valueId.value_id]
-        payload = hassDevice.mode_map ? hassDevice.mode_map[payload] : payload
+        let hassDevice = this.discovered[valueId.value_id]
+        if (hassDevice) {
+          // for thermostat_fan_mode command class use the fan_mode_map
+          if (valueId.class_id === 0x44 && hassDevice.fan_mode_map) payload = hassDevice.fan_mode_map[payload]
+          // for other command classes use the mode_map
+          else if (hassDevice.mode_map) payload = hassDevice.mode_map[payload]
+        }
       }
 
       // switch_toggle_binary and color
       if (valueId.class_id === 0x28) payload = 1
       else if (valueId.class_id === 0x29) payload = valueId.value > 0 ? 0 : 0xFF
       else if (valueId.class_id === 0x33 && typeof payload === 'string') {
-        var rgb = payload.split(',')
+        let rgb = payload.split(',')
         if (rgb.length === 3) {
           payload = '#' + rgbToHex(rgb[0]) + rgbToHex(rgb[1]) + rgbToHex(rgb[2])
         }
@@ -535,10 +540,13 @@ Gateway.prototype.parsePayload = function (payload, valueId, valueConf) {
     }
 
     if (valueConf && isValidOperation(valueConf.postOperation)) {
-      var op = valueConf.postOperation
+      let op = valueConf.postOperation
 
       // revert operation to write
-      if (op.includes('/')) { op = op.replace('/', '*') } else if (op.includes('*')) { op = op.replace('*', '/') } else if (op.includes('+')) { op = op.replace('+', '-') } else if (op.includes('-')) { op = op.replace('-', '+') }
+      if (op.includes('/')) op = op.replace('/', '*')
+      else if (op.includes('*')) op = op.replace('*', '/')
+      else if (op.includes('+')) op = op.replace('+', '-')
+      else if (op.includes('-')) op = op.replace('-', '+')
 
       payload = eval(payload + op)
     }


### PR DESCRIPTION
With the current behavior for thermostat/climate devices values received from HASS for fan modes are translated using the mode_map. However, the mode_map only maps modes for the hvac mode, not the fan mode.

This change makes it so the fan mode command class will map its values against the fan_mode_map instead of the mode_map.