### PR TITLE
simplify the mapped values template by using jinja's default filter

### DIFF
--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -462,21 +462,26 @@ function getDiscoveryTopic (hassDevice, nodeName) {
  * @param {Object} modeMap The Object with mode mapping key : value
  * @param {Boolean} integerList Gateway setting for sending list values as integer index
  * @param {String} defaultValue The default value for the mode
- * @returns A string with the template to use for mode
+ * @returns {String} The template to use for the mode
  */
-function getMappedValues (valueId, modeMap, integerList, defaultValue) {
-  var map = {}
-  for (const k in modeMap) map[modeMap[k]] = k
+function getMappedValuesTemplate (valueId, modeMap, integerList, defaultValue) {
+  let valueFilter = ''
+  let map = {}
+  for (const key in modeMap) map[modeMap[key]] = key
+  let finalMap = map
 
-  if (!integerList) return { map: map, check: 'values[value_json.value] if value_json.value in values.keys() else \'' + defaultValue + '\'' }
+  if (integerList) {
+    valueFilter = ' | string'
+    let mapi = {}
 
-  var mapi = {}
+    for (let i = 0; i < valueId.values.length; i++) {
+      mapi[i.toString()] = map[valueId.values[i]]
+    }
 
-  for (let i = 0; i < valueId.values.length; i++) {
-    mapi[i.toString()] = map[valueId.values[i]]
+    finalMap = mapi
   }
 
-  return { map: mapi, check: 'values[value_json.value | string] if value_json.value | string in values else \'' + defaultValue + '\'' }
+  return `{{ ${JSON.stringify(finalMap)}[value_json.value${valueFilter}] | default('${defaultValue}') }}`
 }
 
 /**
@@ -742,8 +747,7 @@ Gateway.prototype.discoverDevice = function (node, hassDevice) {
         if (mode !== undefined) {
           setId = hassDevice.setpoint_topic && hassDevice.setpoint_topic[mode.value] ? hassDevice.setpoint_topic[mode.value] : hassDevice.default_setpoint
           // only setup modes if a state topic was defined
-          let map = getMappedValues(mode, hassDevice.mode_map, this.config.integerList, 'off')
-          payload.mode_state_template = `{% set values = ${JSON.stringify(map.map)} %} {{ ${map.check} }}`
+          payload.mode_state_template = getMappedValuesTemplate(mode, hassDevice.mode_map, this.config.integerList, 'off')
           payload.mode_state_topic = this.mqtt.getTopic(this.valueTopic(node, mode))
           payload.mode_command_topic = payload.mode_state_topic + '/set'
         } else {
@@ -763,8 +767,7 @@ Gateway.prototype.discoverDevice = function (node, hassDevice) {
           payload.fan_mode_command_topic = payload.fan_mode_state_topic + '/set'
 
           if (hassDevice.fan_mode_map) {
-            let map = getMappedValues(mode, hassDevice.fan_mode_map, this.config.integerList, 'auto')
-            payload.fan_mode_state_template = `{% set values = ${JSON.stringify(map.map)} %} {{ ${map.check} }}`
+            payload.fan_mode_state_template = getMappedValuesTemplate(fan, hassDevice.fan_mode_map, this.config.integerList, 'auto')
           }
         }
 


### PR DESCRIPTION
This simplifies the mode map template by eliminating the conditional and just using jinja's default filter instead. I was able to test it with string values but not with integer values.