### PR TITLE
default precision to 0.1 on hass discovery climate devices

### DIFF
--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -773,7 +773,12 @@ Gateway.prototype.discoverDevice = function (node, hassDevice) {
         }
 
         let currTemp = node.values[payload.current_temperature_topic]
-        if (currTemp !== undefined) payload.current_temperature_topic = this.mqtt.getTopic(this.valueTopic(node, currTemp))
+        if (currTemp !== undefined) {
+          payload.current_temperature_topic = this.mqtt.getTopic(this.valueTopic(node, currTemp))
+          // hass will default the precision to 0.1 for Celsius and 1.0 for Fahrenheit.
+          // 1.0 is not granular enough as a default and there seems to be no harm in making it more precise.
+          if (!payload.precision) payload.precision = 0.1
+        }
       } else {
         payload = hassDevice.discovery_payload
 


### PR DESCRIPTION
Have a more precise reading as a default seems to do no harm and will give better reading for those who have thermostats that report temperature with a more granular precision than 1.0 degree.

Users can still override the precision by setting it in the customDevices.json or the devices.js. If no precision is set then the default is used.