### PR TITLE
Added discovery configuration for fibaro FGS222 and the Qubino flush shutter

### DIFF
--- a/hass/devices.js
+++ b/hass/devices.js
@@ -61,21 +61,21 @@ var DANFOSS_TRV_ZWAVE = {
   }
 }
 
-// var COVER = {
-//   type: 'cover',
-//   object_id: 'position',
-//   values: ['38-1-0'],
-//   discovery_payload: {
-//     command_topic: "38-1-0",
-//     position_topic: "38-1-0",
-//     set_position_topic: "38-1-0",
-//     value_template: "{{ (value_json.value / 99 * 100) | round(0) }}",
-//     position_open: 99,
-//     position_closed: 0,
-//     payload_open: "99",
-//     payload_close: "0"
-//   }
-// }
+var COVER = {
+  type: 'cover',
+  object_id: 'position',
+  values: ['38-1-0'],
+  discovery_payload: {
+    command_topic: "38-1-0",
+    position_topic: "38-1-0",
+    set_position_topic: "38-1-0",
+    value_template: "{{ (value_json.value / 99 * 100) | round(0) }}",
+    position_open: 99,
+    position_closed: 0,
+    payload_open: "99",
+    payload_close: "0"
+  }
+}
 
 module.exports = {
   '411-1-1': [
@@ -127,6 +127,8 @@ module.exports = {
   '328-3-3': [SPIRIT_ZWAVE_PLUS],
   '2-4-5': [DANFOSS_TRV_ZWAVE], // DanfossZ
   '2-373-5': [DANFOSS_TRV_ZWAVE], // Danfoss LC-13
-  '2-40976-266': [DANFOSS_TRV_ZWAVE] // Popp Radiator Thermostat
+  '2-40976-266': [DANFOSS_TRV_ZWAVE], // Popp Radiator Thermostat
+  '345-82-3': [COVER], //Qubin0 flush shutter
+  '271-4096-770': [COVER] //Fibaro FGS222
 
 }


### PR DESCRIPTION
Added support for discovery of 2 cover devices for home assistant.
- Fibaro FGS222
- Qubino flush shutter

All functions of the cover work except for the stop button.
It isn't possible to make it work with the MQTT cover implementation in hass.
For stopping a cover you need to send false to 38/1/2. This isn't possible with the MQTT cover implementation in hass. That implementation uses only 1 command topic where you can send a open, close and stop command to.

Users who need the stop command can better use the template cover.
Example:
```
sensor:
  - platform: mqtt
    name: "zonwering_woonkamer"
    state_topic: "zwave2mqtt/8/38/1/0"
    value_template: "{{ (value_json.value / 99 * 100) | round(0) }}"
    
cover:
  - platform: template
    covers:
      zonwering_woonkamer:
        friendly_name: "Zonwering woonkamer"
        position_template: "{{ ((states('sensor.zonwering_woonkamer')|int)) }}"
        open_cover:
          service: mqtt.publish
          data_template:
            topic: "zwave2mqtt/8/38/1/1/set"
            payload: 'true'
        close_cover:
          service: mqtt.publish
          data_template:
            topic: "zwave2mqtt/8/38/1/2/set"
            payload: 'true'
        stop_cover:
          service: mqtt.publish
          data_template:
            topic: "zwave2mqtt/8/38/1/2/set"
            payload: 'false'
        set_cover_position:
          service: mqtt.publish
          data_template:
            topic: "zwave2mqtt/8/38/1/0/set"
            payload: "{{ position }}"
```
