### PR TITLE
allow a zwave plugin to be defined exposing the zwave client to external js

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ Zwave settings:
 - **Configuration Path**: The path to Openzwave devices config db
 - **Assume Awake**: Assume Devices that support the Wakeup Class are awake when starting up OZW
 - **Auto Update Config File**: Auto update Zwave devices database
+- **Hidden settings**: advanced settings not visible to the user interface, you can edit these by setting in the settings.json
+  - `zwave.plugin` defines a js script that will be included with the `this` context of the zwave client, for example you could set this to `hack` and include a `hack.js` in the root of the app with `module.exports = zw => {zw.client.on("scan complete", () => console.log("scan complete")}`
 
 ### MQTT
 

--- a/lib/ZwaveClient.js
+++ b/lib/ZwaveClient.js
@@ -157,7 +157,12 @@ async function init (cfg, socket) {
   } else {
     this.client = CLIENT = new OpenZWave(options)
     if (cfg.plugin) {
-      require(cfg.plugin)(this)
+      try {
+        require(cfg.plugin)(this)
+      }
+      catch (error) {
+        debug(`Error while loading ${cfg.plugin} plugin`, error.message)
+      }
     }
   }
 

--- a/lib/ZwaveClient.js
+++ b/lib/ZwaveClient.js
@@ -156,6 +156,9 @@ async function init (cfg, socket) {
     this.client.updateOptions(options)
   } else {
     this.client = CLIENT = new OpenZWave(options)
+    if (cfg.plugin) {
+      require(cfg.plugin)(this)
+    }
   }
 
   this.nodes = []

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -125,6 +125,7 @@
                         hint="Path to devices library DB. If not set the default path will be used based on your OS"
                       ></v-text-field>
                     </v-flex>
+                    <input type="hidden" :value="zwave.plugin">
                   </v-layout>
                 </v-card-text>
               </v-card>


### PR DESCRIPTION
As discussed in and closes #359 [[feat] expose the zwave client](/OpenZWave/Zwave2Mqtt/issues/359)

First time i've touched anything to do with vue, so no idea if this is the right/best way to do it?