### PR TITLE
map temperature units to hass values

### DIFF
--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -990,7 +990,11 @@ Gateway.prototype.discoverValue = function (node, valueId) {
         Object.assign(cfg.discovery_payload, sensor.props || {})
 
         if (valueId.units) {
-          cfg.discovery_payload.unit_of_measurement = valueId.units
+          let hassUnitOfMeasurementMap = {
+            'C': '°C',
+            'F': '°F'
+          }
+          cfg.discovery_payload.unit_of_measurement = hassUnitOfMeasurementMap[valueId.units] || valueId.units
         }
 
         // check if there is a custom value configuration for this valueID


### PR DESCRIPTION
https://github.com/OpenZWave/Zwave2Mqtt/issues/357

home assistant uses ```°C``` and ```°F``` for temperature units instead of plain ```C``` and ```F```.

Thus we need to either have zwave2mqtt convert it as part of the hass device JSON template, or handle it on home assistant side to override unit of measurement for every temperature sensor device.

This PR handles it on zwave2mqtt side.