### PR TITLE
Bug #424 Fixing display issue on mobile

### DIFF
--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -106,16 +106,16 @@
               </v-layout>
 
               <v-layout row>
-                <v-flex xs2>
+                <v-flex>
                   <v-subheader>Device ID: {{selectedNode.device_id}}</v-subheader>
                 </v-flex>
               </v-layout>
 
               <v-layout row>
-                <v-flex xs2>
+                <v-flex xs4>
                   <v-subheader>Name: {{selectedNode.name}}</v-subheader>
                 </v-flex>
-                <v-flex xs4>
+                <v-flex xs8>
                   <v-text-field
                     label="New name"
                     append-outer-icon="send"
@@ -128,10 +128,10 @@
               </v-layout>
 
               <v-layout row>
-                <v-flex xs2>
+                <v-flex xs4>
                   <v-subheader>Location: {{selectedNode.loc}}</v-subheader>
                 </v-flex>
-                <v-flex xs4>
+                <v-flex xs8>
                   <v-text-field
                     label="New Location"
                     append-outer-icon="send"


### PR DESCRIPTION
The labels overlapped the new name/location fields. Changed the xs sizing to 4 and 8 for the label and input respectively. Also made the ID full width.