### PR TITLE
fix: improved watch logic of customDevices

### DIFF
--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -25,65 +25,74 @@ var allDevices = hassDevices // will contain customDevices + hassDevices
 
 debug.color = 2
 
-// try to watch a file for changes; if it disappears or doesn't exist watch the
-// directory, and retry the file watch if the directory shows changes
-const watch = (filename, fn) => {
-  var watcher = null
-  try {
-    watcher = fs.watch(filename, e => {
-      const exists = fs.existsSync(filename)
+// watchCustomDevices performs an initial loadCustomDevices, and then sets up a
+// watch on the file that was loaded. When that watch triggers, it calls
+// loadCustomDevices again. If loadCustomDevices ever loads a different file
+// than the initial file, the watch is switched to that new file.
+var customDeviceWatcher = null
+const watchCustomDevices = (last) => {
+  return () => {
+    var result = loadCustomDevices()
 
-      if (exists) {
-        fn()
-      }
+    if (result != last && customDeviceWatcher != null) {
+      // We'll be switching our watch.
+      customDeviceWatcher.close()
+      customDeviceWatcher = null
+    }
 
-      if (e === 'rename' || !exists) {
-        debug('re-setting watch on ' + filename)
-        watcher.close()
-        watch(filename, fn)
+    if (result) {
+      // Load succeeded!
+      if (customDeviceWatcher == null) {
+        // But we have no watcher, either because it was mis-matched or this
+        // is the first time; so set up a watcher.
+        customDeviceWatcher = fs.watch(result, watchCustomDevices(result))
       }
-    })
-  } catch {
-    debug(
-      'failed to set watch on',
-      filename,
-      ', will watch directory and try again'
-    )
-    watcher = fs.watch(path.dirname(filename), () => {
-      if (fs.existsSync(filename)) {
-        watcher.close()
-        watch(filename, fn)
-        fn()
-      }
-    })
+      return
+    }
+
+    // Load failed! If we need a watcher, set one on the directory
+    if (customDeviceWatcher == null) {
+      customDeviceWatcher = fs.watch(path.dirname(customDevicesJsPath), watchCustomDevices(null))
+    }
   }
 }
 
-var lastCustomDevicesLoad = 0
-// try to load the named file either as a .js lib if `lib` is true, or as JSON
-// otherwise
-function loadCustomDevices (filename, lib) {
-  if (Date.now() - lastCustomDevicesLoad < 1000) {
-    return
-  }
+const customDevicesJsPath = utils.joinPath(true, CUSTOM_DEVICES) + '.js'
+const customDevicesJsonPath = utils.joinPath(true, CUSTOM_DEVICES) + '.json'
 
-  var devices
+var lastCustomDevicesLoad = null
+// loadCustomDevices attempts to load a custom devices file, preferring `.js`
+// but falling back to `.json` only if a `.js` file does not exist. It returns
+// the path to the file that was loaded, or null, if a file could not be
+// loaded.
+const loadCustomDevices = () => {
+  var loaded = ""
+  var devices = null
+
   try {
-    if (lib) {
-      devices = reqlib(filename)
+    if (fs.existsSync(customDevicesJsPath)) {
+      loaded = customDevicesJsPath
+      devices = reqlib(CUSTOM_DEVICES)
+    } else if (fs.existsSync(customDevicesJsonPath)) {
+      loaded = customDevicesJsonPath
+      devices = JSON.parse(fs.readFileSync(loaded))
     } else {
-      devices = JSON.parse(fs.readFileSync(filename))
+      debug('no custom devices sources found')
+      return null
     }
-  } catch (error) {
-    if (error.message.indexOf('Cannot find module') >= 0) {
-      debug('Error loading', filename, ': not found')
-    } else {
-      debug('Error loading', filename, ':', error.message)
-    }
-    return
+  } catch(error) {
+    debug('failed to load ' + loaded + ':', error)
+    return null
   }
 
-  lastCustomDevicesLoad = Date.now()
+  const sha = require('crypto').createHash('sha256').update(JSON.stringify(devices)).digest('hex')
+  if (lastCustomDevicesLoad == sha) {
+    return loaded
+  }
+
+  debug('loading custom devices from', loaded)
+
+  lastCustomDevicesLoad = sha
 
   allDevices = Object.assign({}, hassDevices, devices)
   debug(
@@ -91,22 +100,12 @@ function loadCustomDevices (filename, lib) {
     Object.keys(devices).length,
     'custom Hass devices configurations'
   )
+
+  return loaded
 }
 
-// Set a watch on and try to load JS file
-const customDevicesJsPath = utils.joinPath(true, CUSTOM_DEVICES) + '.js'
-watch(customDevicesJsPath, () => {
-  loadCustomDevices(CUSTOM_DEVICES, true)
-})
-loadCustomDevices(CUSTOM_DEVICES, true)
-
-// Set a watch on and try to load JSON file. Note that if both exist, 1s
-// cooldown in means we'll ignore the JSON file.
-const customDevicesJsonPath = utils.joinPath(true, CUSTOM_DEVICES) + '.json'
-watch(customDevicesJsonPath, () => {
-  loadCustomDevices(customDevicesJsonPath, false)
-})
-loadCustomDevices(customDevicesJsonPath, false)
+// Fake an initial watch trigger
+watchCustomDevices(null)()
 
 /**
  * The constructor

--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -5,6 +5,7 @@
 'use strict'
 
 const fs = require('fs')
+const path = require('path')
 const reqlib = require('app-root-path').require
 const utils = reqlib('/lib/utils.js')
 const EventEmitter = require('events')
@@ -24,28 +25,66 @@ var allDevices = hassDevices // will contain customDevices + hassDevices
 
 debug.color = 2
 
-// util function to watch for file changes, prevents the watch to be called twice
-
-const watch = (path, fn) => {
+// try to watch a file for changes; if it disappears or doesn't exist watch the
+// directory, and retry the file watch if the directory shows changes
+const watch = (filename, fn) => {
   var watcher = null
   try {
-    watcher = fs.watch(path, e => {
-      if (e === 'rename') {
-        debug('re-setting watch on ' + path)
-        watcher.close()
-        watch(path, fn)
+    watcher = fs.watch(filename, e => {
+      const exists = fs.existsSync(filename)
+
+      if (exists) {
+        fn()
       }
 
-      fn()
+      if (e === 'rename' || !exists) {
+        debug('re-setting watch on ' + filename)
+        watcher.close()
+        watch(filename, fn)
+      }
     })
   } catch {
-    setTimeout(() => {
-      watch(path, fn)
-    }, 500)
+    debug(
+      'failed to set watch on',
+      filename,
+      ', will watch directory and try again'
+    )
+    watcher = fs.watch(path.dirname(filename), () => {
+      if (fs.existsSync(filename)) {
+        watcher.close()
+        watch(filename, fn)
+        fn()
+      }
+    })
   }
 }
 
-function loadCustomDevices (devices) {
+var lastCustomDevicesLoad = 0
+// try to load the named file either as a .js lib if `lib` is true, or as JSON
+// otherwise
+function loadCustomDevices (filename, lib) {
+  if (Date.now() - lastCustomDevicesLoad < 1000) {
+    return
+  }
+
+  var devices
+  try {
+    if (lib) {
+      devices = reqlib(filename)
+    } else {
+      devices = JSON.parse(fs.readFileSync(filename))
+    }
+  } catch (error) {
+    if (error.message.indexOf('Cannot find module') >= 0) {
+      debug('Error loading', filename, ': not found')
+    } else {
+      debug('Error loading', filename, ':', error.message)
+    }
+    return
+  }
+
+  lastCustomDevicesLoad = Date.now()
+
   allDevices = Object.assign({}, hassDevices, devices)
   debug(
     'Loaded',
@@ -54,43 +93,20 @@ function loadCustomDevices (devices) {
   )
 }
 
-var lastCustomDevicesLoad = 0
-function tryLoadCustomDevices (file, first) {
-  if (Date.now() - lastCustomDevicesLoad < 1000) {
-    return
-  }
+// Set a watch on and try to load JS file
+const customDevicesJsPath = utils.joinPath(true, CUSTOM_DEVICES) + '.js'
+watch(customDevicesJsPath, () => {
+  loadCustomDevices(CUSTOM_DEVICES, true)
+})
+loadCustomDevices(CUSTOM_DEVICES, true)
 
-  try {
-    const fileContent = fs.readFileSync(file)
-    loadCustomDevices(JSON.parse(fileContent))
-    lastCustomDevicesLoad = Date.now()
-  } catch (error) {
-    if (first) {
-      debug('Error while reading', file, error.message, '(will retry)')
-      setTimeout(() => {
-        tryLoadCustomDevices(file, false)
-      }, 100)
-    } else {
-      debug('Error while reading', file, error.message)
-    }
-  }
-}
-
-try {
-  const devices = reqlib(CUSTOM_DEVICES)
-  loadCustomDevices(devices)
-  CUSTOM_DEVICES = utils.joinPath(true, CUSTOM_DEVICES)
-
-  watch(CUSTOM_DEVICES + '.json', () => {
-    tryLoadCustomDevices(CUSTOM_DEVICES + '.json', true)
-  })
-} catch (error) {
-  if (error.message.indexOf('Cannot find module') >= 0) {
-    debug('No customDevices file found')
-  } else {
-    debug('Error while parsing customDevices file:', error.message)
-  }
-}
+// Set a watch on and try to load JSON file. Note that if both exist, 1s
+// cooldown in means we'll ignore the JSON file.
+const customDevicesJsonPath = utils.joinPath(true, CUSTOM_DEVICES) + '.json'
+watch(customDevicesJsonPath, () => {
+  loadCustomDevices(customDevicesJsonPath, false)
+})
+loadCustomDevices(customDevicesJsonPath, false)
 
 /**
  * The constructor

--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -29,22 +29,22 @@ debug.color = 2
 // doesn't exist), instead watch the directory. If the directory watch
 // triggers, cancel it and try to watch the file again. Meanwhile spam `fn()`
 // on any change, trusting that it's idempotent.
+var watchers = new Map()
 const watch = (filename, fn) => {
-  var watcher
   try {
-    watcher = fs.watch(filename, e => {
+    watchers.set(filename, fs.watch(filename, e => {
       fn()
       if (e === 'rename') {
-        watcher.close()
+        watchers.get(filename).close()
         watch(filename, fn)
       }
-    })
+    }))
   } catch {
-    watcher = fs.watch(path.dirname(filename), () => {
-      watcher.close()
+    watchers.set(filename, fs.watch(path.dirname(filename), () => {
+      watchers.get(filename).close()
       watch(filename, fn)
       fn()
-    })
+    }))
   }
 }
 
@@ -97,8 +97,8 @@ const loadCustomDevices = () => {
 }
 
 loadCustomDevices()
-watch(customDevicesJsPath, loadCustomDevices)
-watch(customDevicesJsonPath, loadCustomDevices)
+watch(customDevicesJsPath, 0, loadCustomDevices)
+watch(customDevicesJsonPath, 1, loadCustomDevices)
 
 /**
  * The constructor

--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -32,19 +32,25 @@ debug.color = 2
 var watchers = new Map()
 const watch = (filename, fn) => {
   try {
-    watchers.set(filename, fs.watch(filename, e => {
-      fn()
-      if (e === 'rename') {
+    watchers.set(
+      filename,
+      fs.watch(filename, e => {
+        fn()
+        if (e === 'rename') {
+          watchers.get(filename).close()
+          watch(filename, fn)
+        }
+      })
+    )
+  } catch {
+    watchers.set(
+      filename,
+      fs.watch(path.dirname(filename), () => {
         watchers.get(filename).close()
         watch(filename, fn)
-      }
-    }))
-  } catch {
-    watchers.set(filename, fs.watch(path.dirname(filename), () => {
-      watchers.get(filename).close()
-      watch(filename, fn)
-      fn()
-    }))
+        fn()
+      })
+    )
   }
 }
 

--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -41,7 +41,7 @@ const watch = (path, fn) => {
   } catch {
     setTimeout(() => {
       watch(path, fn)
-    }, 100)
+    }, 500)
   }
 }
 

--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -25,17 +25,25 @@ var allDevices = hassDevices // will contain customDevices + hassDevices
 debug.color = 2
 
 // util function to watch for file changes, prevents the watch to be called twice
-const watch = (path, fn) => {
-  var lock = false
-  fs.watch(path, function () {
-    if (lock) return
 
-    lock = true
-    fn()
-    setTimeout(() => {
-      lock = false
-    }, 1000)
-  })
+var lastCustomLoad = 0
+const watch = (path, fn) => {
+  var watcher = null
+  try {
+    watcher = fs.watch(path, (e) => {
+      if (e === 'rename') {
+        watcher.close()
+        watch(path,fn)
+      }
+
+      if (Date.now() - lastCustomLoad > 1000) {
+        lastCustomLoad = Date.now()
+        fn()
+      }
+    })
+  } catch {
+    setTimeout(() => {watch(path,fn)}, 100)
+  }
 }
 
 function loadCustomDevices (devices) {

--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -80,7 +80,7 @@ const loadCustomDevices = () => {
     .createHash('sha256')
     .update(JSON.stringify(devices))
     .digest('hex')
-  if (lastCustomDevicesLoad == sha) {
+  if (lastCustomDevicesLoad === sha) {
     return
   }
 

--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -26,20 +26,17 @@ debug.color = 2
 
 // util function to watch for file changes, prevents the watch to be called twice
 
-var lastCustomLoad = 0
 const watch = (path, fn) => {
   var watcher = null
   try {
     watcher = fs.watch(path, (e) => {
       if (e === 'rename') {
+        debug('re-setting watch on ' + path)
         watcher.close()
         watch(path,fn)
       }
 
-      if (Date.now() - lastCustomLoad > 1000) {
-        lastCustomLoad = Date.now()
-        fn()
-      }
+      fn()
     })
   } catch {
     setTimeout(() => {watch(path,fn)}, 100)
@@ -55,20 +52,34 @@ function loadCustomDevices (devices) {
   )
 }
 
+var lastCustomDevicesLoad = 0
+function tryLoadCustomDevices (file, first) {
+  if (Date.now() - lastCustomDevicesLoad < 1000) {
+    return
+  }
+
+  try {
+    const fileContent = fs.readFileSync(file)
+    loadCustomDevices(JSON.parse(fileContent))
+    lastCustomDevicesLoad = Date.now()
+  } catch (error) {
+    if (first) {
+      debug('Error while reading', file, error.message, '(will retry)')
+      setTimeout( () => { tryLoadCustomDevices(file,false) }, 100)
+    } else {
+      debug('Error while reading', file, error.message)
+    }
+  }
+}
+
 try {
   const devices = reqlib(CUSTOM_DEVICES)
   loadCustomDevices(devices)
   CUSTOM_DEVICES = utils.joinPath(true, CUSTOM_DEVICES)
-  if (fs.existsSync(CUSTOM_DEVICES + '.json')) {
-    watch(CUSTOM_DEVICES + '.json', function () {
-      try {
-        const fileContent = fs.readFileSync(CUSTOM_DEVICES + '.json')
-        loadCustomDevices(JSON.parse(fileContent))
-      } catch (error) {
-        debug('Error while reading', CUSTOM_DEVICES + '.json', error.message)
-      }
-    })
-  }
+
+  watch(CUSTOM_DEVICES + '.json', () => {
+    tryLoadCustomDevices(CUSTOM_DEVICES + '.json', true)
+  })
 } catch (error) {
   if (error.message.indexOf('Cannot find module') >= 0) {
     debug('No customDevices file found')

--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -33,13 +33,13 @@ const watch = (path, fn) => {
       if (e === 'rename') {
         debug('re-setting watch on ' + path)
         watcher.close()
-        watch(path,fn)
+        watch(path, fn)
       }
 
       fn()
     })
   } catch {
-    setTimeout(() => {watch(path,fn)}, 100)
+    setTimeout(() => { watch(path, fn) }, 100)
   }
 }
 
@@ -65,7 +65,7 @@ function tryLoadCustomDevices (file, first) {
   } catch (error) {
     if (first) {
       debug('Error while reading', file, error.message, '(will retry)')
-      setTimeout( () => { tryLoadCustomDevices(file,false) }, 100)
+      setTimeout(() => { tryLoadCustomDevices(file, false) }, 100)
     } else {
       debug('Error while reading', file, error.message)
     }

--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -25,35 +25,26 @@ var allDevices = hassDevices // will contain customDevices + hassDevices
 
 debug.color = 2
 
-// watchCustomDevices performs an initial loadCustomDevices, and then sets up a
-// watch on the file that was loaded. When that watch triggers, it calls
-// loadCustomDevices again. If loadCustomDevices ever loads a different file
-// than the initial file, the watch is switched to that new file.
-var customDeviceWatcher = null
-const watchCustomDevices = (last) => {
-  return () => {
-    var result = loadCustomDevices()
-
-    if (result != last && customDeviceWatcher != null) {
-      // We'll be switching our watch.
-      customDeviceWatcher.close()
-      customDeviceWatcher = null
-    }
-
-    if (result) {
-      // Load succeeded!
-      if (customDeviceWatcher == null) {
-        // But we have no watcher, either because it was mis-matched or this
-        // is the first time; so set up a watcher.
-        customDeviceWatcher = fs.watch(result, watchCustomDevices(result))
+// watcher initiates a watch on a file. if this fails (e.g., because the file
+// doesn't exist), instead watch the directory. If the directory watch
+// triggers, cancel it and try to watch the file again. Meanwhile spam `fn()`
+// on any change, trusting that it's idempotent.
+const watch = (filename, fn) => {
+  var watcher
+  try {
+    watcher = fs.watch(filename, e => {
+      fn()
+      if (e === 'rename') {
+        watcher.close()
+        watch(filename, fn)
       }
-      return
-    }
-
-    // Load failed! If we need a watcher, set one on the directory
-    if (customDeviceWatcher == null) {
-      customDeviceWatcher = fs.watch(path.dirname(customDevicesJsPath), watchCustomDevices(null))
-    }
+    })
+  } catch {
+    watcher = fs.watch(path.dirname(filename), () => {
+      watcher.close()
+      watch(filename, fn)
+      fn()
+    })
   }
 }
 
@@ -62,11 +53,11 @@ const customDevicesJsonPath = utils.joinPath(true, CUSTOM_DEVICES) + '.json'
 
 var lastCustomDevicesLoad = null
 // loadCustomDevices attempts to load a custom devices file, preferring `.js`
-// but falling back to `.json` only if a `.js` file does not exist. It returns
-// the path to the file that was loaded, or null, if a file could not be
-// loaded.
+// but falling back to `.json` only if a `.js` file does not exist. It stores
+// a sha of the loaded data, and will skip re-loading any time the data has
+// not changed.
 const loadCustomDevices = () => {
-  var loaded = ""
+  var loaded = ''
   var devices = null
 
   try {
@@ -78,16 +69,19 @@ const loadCustomDevices = () => {
       devices = JSON.parse(fs.readFileSync(loaded))
     } else {
       debug('no custom devices sources found')
-      return null
+      return
     }
-  } catch(error) {
+  } catch (error) {
     debug('failed to load ' + loaded + ':', error)
-    return null
+    return
   }
 
-  const sha = require('crypto').createHash('sha256').update(JSON.stringify(devices)).digest('hex')
+  const sha = require('crypto')
+    .createHash('sha256')
+    .update(JSON.stringify(devices))
+    .digest('hex')
   if (lastCustomDevicesLoad == sha) {
-    return loaded
+    return
   }
 
   debug('loading custom devices from', loaded)
@@ -100,12 +94,11 @@ const loadCustomDevices = () => {
     Object.keys(devices).length,
     'custom Hass devices configurations'
   )
-
-  return loaded
 }
 
-// Fake an initial watch trigger
-watchCustomDevices(null)()
+loadCustomDevices()
+watch(customDevicesJsPath, loadCustomDevices)
+watch(customDevicesJsonPath, loadCustomDevices)
 
 /**
  * The constructor

--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -29,7 +29,7 @@ debug.color = 2
 const watch = (path, fn) => {
   var watcher = null
   try {
-    watcher = fs.watch(path, (e) => {
+    watcher = fs.watch(path, e => {
       if (e === 'rename') {
         debug('re-setting watch on ' + path)
         watcher.close()
@@ -39,7 +39,9 @@ const watch = (path, fn) => {
       fn()
     })
   } catch {
-    setTimeout(() => { watch(path, fn) }, 100)
+    setTimeout(() => {
+      watch(path, fn)
+    }, 100)
   }
 }
 
@@ -65,7 +67,9 @@ function tryLoadCustomDevices (file, first) {
   } catch (error) {
     if (first) {
       debug('Error while reading', file, error.message, '(will retry)')
-      setTimeout(() => { tryLoadCustomDevices(file, false) }, 100)
+      setTimeout(() => {
+        tryLoadCustomDevices(file, false)
+      }, 100)
     } else {
       debug('Error while reading', file, error.message)
     }

--- a/test/lib/Gateway.test.js
+++ b/test/lib/Gateway.test.js
@@ -57,4 +57,12 @@ describe('#Gateway', () => {
       })
     })
   })
+
+  afterEach(() => {
+    mod.__get__('watchers').forEach(v => {
+      if (v != null) {
+        v.close()
+      }
+    })
+  })
 })


### PR DESCRIPTION
Although my specific use case is still broken because of the behavior of docker single file mounts, this appears to fix #670 

# Before

```
$ docker run --name=z2m --entrypoint=/bin/sh -it robertslando/zwave2mqtt:latest
$ echo '{}' > store/customDevices.json
$ node bin/ww
…
  z2m:Gateway Loaded 0 custom Hass devices configurations +0ms
…
```

Then, in a new window:
```
$ docker exec -it z2m /bin/sh
$ apk add vim
$ vim store/customDevices.json
…add something / change the file; `:wq`
```

Back in the first window, I see:
```
  z2m:Gateway Error while reading /usr/src/app/store/customDevices.json ENOENT: no such file or directory, open '/usr/src/app/store/customDevices.json' +20s
```

# After

```
  z2m:Gateway re-setting watch on /usr/src/app/store/customDevices.json +14s
  z2m:Gateway Error while reading /usr/src/app/store/customDevices.json ENOENT: no such file or directory, open '/usr/src/app/store/customDevices.json' (will retry) +1ms
  z2m:Gateway Loaded 1 custom Hass devices configurations +101ms
```