### PR TITLE
fix watch pt 2 -- bad code from a change that didn't pan out

### DIFF
--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -103,8 +103,8 @@ const loadCustomDevices = () => {
 }
 
 loadCustomDevices()
-watch(customDevicesJsPath, 0, loadCustomDevices)
-watch(customDevicesJsonPath, 1, loadCustomDevices)
+watch(customDevicesJsPath, loadCustomDevices)
+watch(customDevicesJsonPath, loadCustomDevices)
 
 /**
  * The constructor


### PR DESCRIPTION
Tested by overlaying the new lib/Gateway.js & store into the upstream docker container:

```
$ docker run -it -v $PWD/lib:/usr/src/app/lib -v $PWD/store:/usr/src/app/store robertslando/zwave2mqtt
  z2m:Store settings.json not found +0ms
  z2m:Store scenes.json not found +1ms
  z2m:Store nodes.json not found +1ms
  z2m:Gateway no custom devices sources found +0ms
  z2m:App Zwave2Mqtt version: 4.0.1 +0ms
  z2m:App Application path:/usr/src/app +0ms
  z2m:Gateway Zwave settings are not valid +15ms
  z2m:App Listening on port 8091 +0ms
```

and then creating some files in `store/...`:

```
$ touch store/customDevices.js
…
  z2m:Gateway loading custom devices from /usr/src/app/store/customDevices.js +5s
  z2m:Gateway Loaded 0 custom Hass devices configurations +1ms
$ echo '{"test": {}}' > store/customDevices.json
…
(no logs, because `customDevices.js` is used and it has not changed)
…
$ rm store/customDevices.js
  z2m:Gateway loading custom devices from /usr/src/app/store/customDevices.json +1m
  z2m:Gateway Loaded 1 custom Hass devices configurations +0ms
```