### PR TITLE
close stale issues+prs

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -10,11 +10,11 @@ jobs:
       - uses: actions/stale@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove the stale label or comment or this will be closed in 5 days. To ignore this issue entirely you can add the no-stale label'
+          stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove the stale label or comment or this will be closed in 5 days. To ignore this issue entirely you can add the no-stale label'
           close-issue-message: 'This issue is now closed due to inactivity, you can of course reopen or reference this issue if you see fit.'
-          stale-pr-message: 'This pull-request is stale because it has been open 30 days with no activity. Remove the stale label or comment or this will be closed in 5 days. To ignore this pull-request entirely you can add the no-stale label'
+          stale-pr-message: 'This pull-request is stale because it has been open 90 days with no activity. Remove the stale label or comment or this will be closed in 5 days. To ignore this pull-request entirely you can add the no-stale label'
           close-pr-message: 'This pull-request is now closed due to inactivity, you can of course reopen or reference this pull-request if you see fit.'
-          days-before-stale: 30
+          days-before-stale: 90
           days-before-close: 5
-          exempt-issue-labels: 'no-stale'
+          exempt-issue-labels: 'no-stale,enhancement'
           exempt-pr-labels: 'no-stale'

--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -1,0 +1,20 @@
+name: 'Close stale issues'
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove the stale label or comment or this will be closed in 5 days. To ignore this issue entirely you can add the no-stale label'
+          close-issue-message: 'This issue is now closed due to inactivity, you can of course reopen or reference this issue if you see fit.'
+          stale-pr-message: 'This pull-request is stale because it has been open 30 days with no activity. Remove the stale label or comment or this will be closed in 5 days. To ignore this pull-request entirely you can add the no-stale label'
+          close-pr-message: 'This pull-request is now closed due to inactivity, you can of course reopen or reference this pull-request if you see fit.'
+          days-before-stale: 30
+          days-before-close: 5
+          exempt-issue-labels: 'no-stale'
+          exempt-pr-labels: 'no-stale'


### PR DESCRIPTION
attempt to tidy up the backlog of issues+prs and make sure they're still relevant.
hopefully the text reads friendly enough, suggest we try at 30 and see if we need to increase the days if it's more annoying than useful

adding `no-stale` label will prevent it applying to any of the longer term features/prs etc