### PR TITLE
feat: improve HASS discovery of cover devices

### DIFF
--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -38,7 +38,7 @@ jobs:
             TAGS=$TAGS,${DOCKER_REPO}:$(echo ${GITHUB_REF} | sed "s/refs\/tags\/v//") >> ./TAGS
           fi
 
-          echo "::set-output name=TAGS::${$TAGS}"
+          echo ::set-output name=TAGS::${TAGS}
           echo DOCKER_REPO="${DOCKER_REPO}" >> $GITHUB_ENV
 
       - name: build+push

--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -28,19 +28,15 @@ jobs:
         id: prepare
         run: |
           DOCKER_REPO=robertslando/zwave2mqtt
-          echo ${DOCKER_REPO}:sha-${GITHUB_SHA} > ./TAGS
+          TAGS=${DOCKER_REPO}:sha-${GITHUB_SHA}
 
           if [ "$GITHUB_REF" == "refs/heads/master" ]; then
-            echo "${DOCKER_REPO}:dev" >> ./TAGS
+            TAGS=$TAGS,${DOCKER_REPO}:dev
           fi
           if [ "$GITHUB_EVENT_NAME" == "release" ]; then
-            echo "${DOCKER_REPO}:latest" >> ./TAGS
-            echo "${DOCKER_REPO}:$(echo ${GITHUB_REF} | sed "s/refs\/tags\/v//")\n" >> ./TAGS
+            TAGS=$TAGS,${DOCKER_REPO}:latest
+            TAGS=$TAGS,${DOCKER_REPO}:$(echo ${GITHUB_REF} | sed "s/refs\/tags\/v//") >> ./TAGS
           fi
-          TAGS=$(cat TAGS)"
-          TAGS="${TAGS//'%'/'%25'}"
-          TAGS="${TAGS//$'\n'/'%0A'}"
-          TAGS="${TAGS//$'\r'/'%0D'}"
 
           echo "::set-output name=TAGS::${$TAGS}"
           echo DOCKER_REPO="${DOCKER_REPO}" >> $GITHUB_ENV
@@ -52,5 +48,4 @@ jobs:
           platforms: linux/arm64,linux/amd64,linux/arm/v6,linux/arm/v7,linux/386
           file: docker/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
-          tags: |
-            ${{ steps.prepare.outputs.TAGS }}
+          tags: ${{ steps.prepare.outputs.TAGS }}

--- a/hass/configurations.js
+++ b/hass/configurations.js
@@ -226,14 +226,17 @@ module.exports = {
   },
   cover_position: {
     type: 'cover',
-    object_id: 'cover',
+    object_id: 'position',
     discovery_payload: {
+      state_topic: true,
       command_topic: true,
       position_topic: true,
       set_position_topic: true,
-      set_position_template: '{ "value": {{ position }} }',
-      value_template: '{{ value_json.value }}',
-      state_topic: false
+      value_template: '{{ value_json.value | round(0) }}',
+      position_open: 99,
+      position_closed: 0,
+      payload_open: '99',
+      payload_close: '0'
     }
   },
 

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -605,7 +605,7 @@ module.exports = {
     if (clsAttr) {
       return (
         clsAttr.specific[specificCls] ||
-        'unknownSpecificDeviceType' + specificCls
+        'unknownSpecificDeviceType_' + specificCls
       )
     } else {
       return 'unknownGenericDeviceType_' + genericCls

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -376,22 +376,22 @@ module.exports = {
     // https://github.com/home-assistant/core/blob/dev/homeassistant/components/zwave/const.py#L196
     // 0x00: specific_type_not_used // Available in all Generic types
     0x03: {
-      genericType: 'generic_type_av_control_point',
-      specificTypes: {
+      generic: 'generic_type_av_control_point',
+      specific: {
         0x12: 'specific_type_doorbell',
         0x04: 'specific_type_satellite_receiver',
         0x11: 'specific_type_satellite_receiver_v2'
       }
     },
     0x04: {
-      genericType: 'generic_type_display',
-      specificTypes: {
+      generic: 'generic_type_display',
+      specific: {
         0x01: 'specific_type_simple_display'
       }
     },
     0x40: {
-      genericType: 'generic_type_entry_control',
-      specificTypes: {
+      generic: 'generic_type_entry_control',
+      specific: {
         0x01: 'specific_type_door_lock',
         0x02: 'specific_type_advanced_door_lock',
         0x03: 'specific_type_secure_keypad_door_lock',
@@ -406,8 +406,8 @@ module.exports = {
       }
     },
     0x01: {
-      genericType: 'generic_type_generic_controller',
-      specificTypes: {
+      generic: 'generic_type_generic_controller',
+      specific: {
         0x01: 'specific_type_portable_controller',
         0x02: 'specific_type_portable_scene_controller',
         0x03: 'specific_type_portable_installer_tool',
@@ -416,43 +416,43 @@ module.exports = {
       }
     },
     0x31: {
-      genericType: 'generic_type_meter',
-      specificTypes: {
+      generic: 'generic_type_meter',
+      specific: {
         0x01: 'specific_type_simple_meter',
         0x02: 'specific_type_adv_energy_control',
         0x03: 'specific_type_whole_home_meter_simple'
       }
     },
     0x30: {
-      genericType: 'generic_type_meter_pulse',
-      specificTypes: {}
+      generic: 'generic_type_meter_pulse',
+      specific: {}
     },
     0xff: {
-      genericType: 'generic_type_non_interoperable',
-      specificTypes: {}
+      generic: 'generic_type_non_interoperable',
+      specific: {}
     },
     0x0f: {
-      genericType: 'generic_type_repeater_slave',
-      specificTypes: {
+      generic: 'generic_type_repeater_slave',
+      specific: {
         0x01: 'specific_type_repeater_slave',
         0x02: 'specific_type_virtual_node'
       }
     },
     0x17: {
-      genericType: 'generic_type_security_panel',
-      specificTypes: {
+      generic: 'generic_type_security_panel',
+      specific: {
         0x01: 'specific_type_zoned_security_panel'
       }
     },
     0x50: {
-      genericType: 'generic_type_semi_interoperable',
-      specificTypes: {
+      generic: 'generic_type_semi_interoperable',
+      specific: {
         0x01: 'specific_type_energy_production'
       }
     },
     0xa1: {
-      genericType: 'generic_type_sensor_alarm',
-      specificTypes: {
+      generic: 'generic_type_sensor_alarm',
+      specific: {
         0x05: 'specific_type_adv_zensor_net_alarm_sensor',
         0x10: 'specific_type_adv_zensor_net_smoke_sensor',
         0x01: 'specific_type_basic_routing_alarm_sensor',
@@ -467,21 +467,21 @@ module.exports = {
       }
     },
     0x20: {
-      genericType: 'generic_type_sensor_binary',
-      specificTypes: {
+      generic: 'generic_type_sensor_binary',
+      specific: {
         0x01: 'specific_type_routing_sensor_binary'
       }
     },
     0x21: {
-      genericType: 'generic_type_sensor_multilevel',
-      specificTypes: {
+      generic: 'generic_type_sensor_multilevel',
+      specific: {
         0x01: 'specific_type_routing_sensor_multilevel',
         0x02: 'specific_type_chimney_fan'
       }
     },
     0x02: {
-      genericType: 'generic_type_static_controller',
-      specificTypes: {
+      generic: 'generic_type_static_controller',
+      specific: {
         0x01: 'specific_type_pc_controller',
         0x02: 'specific_type_scene_controller',
         0x03: 'specific_type_static_installer_tool',
@@ -492,8 +492,8 @@ module.exports = {
       }
     },
     0x10: {
-      genericType: 'generic_type_switch_binary',
-      specificTypes: {
+      generic: 'generic_type_switch_binary',
+      specific: {
         0x01: 'specific_type_power_switch_binary',
         0x03: 'specific_type_scene_switch_binary',
         0x04: 'specific_type_power_strip',
@@ -504,8 +504,8 @@ module.exports = {
       }
     },
     0x11: {
-      genericType: 'generic_type_switch_multilevel',
-      specificTypes: {
+      generic: 'generic_type_switch_multilevel',
+      specific: {
         0x05: 'specific_type_class_a_motor_control',
         0x06: 'specific_type_class_b_motor_control',
         0x07: 'specific_type_class_c_motor_control',
@@ -517,8 +517,8 @@ module.exports = {
       }
     },
     0x12: {
-      genericType: 'generic_type_switch_remote',
-      specificTypes: {
+      generic: 'generic_type_switch_remote',
+      specific: {
         0x01: 'specific_type_remote_binary',
         0x02: 'specific_type_remote_multilevel',
         0x03: 'specific_type_remove_toggle_binary',
@@ -526,15 +526,15 @@ module.exports = {
       }
     },
     0x13: {
-      genericType: 'generic_type_switch_toggle',
-      specificTypes: {
+      generic: 'generic_type_switch_toggle',
+      specific: {
         0x01: 'specific_type_switch_toggle_binary',
         0x02: 'specific_type_switch_toggle_multilevel'
       }
     },
     0x08: {
-      genericType: 'generic_type_thermostat',
-      specificTypes: {
+      generic: 'generic_type_thermostat',
+      specific: {
         0x03: 'specific_type_setback_schedule_thermostat',
         0x05: 'specific_type_setback_thermostat',
         0x04: 'specific_type_setpoint_thermostat',
@@ -544,47 +544,47 @@ module.exports = {
       }
     },
     0x16: {
-      genericType: 'generic_type_ventilation',
-      specificTypes: {
+      generic: 'generic_type_ventilation',
+      specific: {
         0x01: 'specific_type_residential_hrv'
       }
     },
     0x09: {
-      genericType: 'generic_type_windows_covering',
-      specificTypes: {
+      generic: 'generic_type_windows_covering',
+      specific: {
         0x01: 'specific_type_simple_window_covering'
       }
     },
     0x15: {
-      genericType: 'generic_type_zip_node',
-      specificTypes: {
+      generic: 'generic_type_zip_node',
+      specific: {
         0x02: 'specific_type_zip_adv_node',
         0x01: 'specific_type_zip_tun_node'
       }
     },
     0x18: {
-      genericType: 'generic_type_wall_controller',
-      specificTypes: {
+      generic: 'generic_type_wall_controller',
+      specific: {
         0x01: 'specific_type_basic_wall_controller'
       }
     },
     0x05: {
-      genericType: 'generic_type_network_extender',
-      specificTypes: {
+      generic: 'generic_type_network_extender',
+      specific: {
         0x01: 'specific_type_secure_extender'
       }
     },
     0x06: {
-      genericType: 'generic_type_appliance',
-      specificTypes: {
+      generic: 'generic_type_appliance',
+      specific: {
         0x01: 'specific_type_general_appliance',
         0x02: 'specific_type_kitchen_appliance',
         0x03: 'specific_type_laundry_appliance'
       }
     },
     0x07: {
-      genericType: 'generic_type_sensor_notification',
-      specificTypes: {
+      generic: 'generic_type_sensor_notification',
+      specific: {
         0x01: 'specific_type_notification_sensor'
       }
     }
@@ -595,7 +595,7 @@ module.exports = {
   genericDeviceClass (cls) {
     var clsAttr = this.genericDeviceClassAttributes(cls)
     if (clsAttr) {
-      return clsAttr.genericType
+      return clsAttr.generic
     } else {
       return 'unknownGenericDeviceType_' + cls
     }
@@ -604,7 +604,7 @@ module.exports = {
     var clsAttr = this.genericDeviceClassAttributes(genericCls)
     if (clsAttr) {
       return (
-        clsAttr.specificTypes[specificCls] ||
+        clsAttr.specific[specificCls] ||
         'unknownSpecificDeviceType' + specificCls
       )
     } else {

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -424,13 +424,13 @@ module.exports = {
     },
     0x30: {
       genericType: 'generic_type_meter_pulse',
-      specificTypes: {},
+      specificTypes: {}
+    },
+    0xff: {
+      genericType: 'generic_type_non_interoperable',
+      specificTypes: {}
     },
     0x0f: {
-      genericType: 'generic_type_non_interoperable',
-      specificTypes: {},
-    },
-    0x15: {
       genericType: 'generic_type_repeater_slave',
       specificTypes: {
         0x01: 'specific_type_repeater_slave',
@@ -539,7 +539,7 @@ module.exports = {
         0x04: 'specific_type_setpoint_thermostat',
         0x02: 'specific_type_thermostat_general',
         0x06: 'specific_type_thermostat_general_v2',
-        0x01: 'specific_type_thermostat_heating',
+        0x01: 'specific_type_thermostat_heating'
       }
     },
     0x16: {
@@ -602,7 +602,10 @@ module.exports = {
   specificDeviceClass (genericCls, specificCls) {
     var clsAttr = this.genericDeviceClassAttributes(genericCls)
     if (clsAttr) {
-      return clsAttr.specificTypes[specificCls] || 'unknownSpecificDeviceType' + specificCls
+      return (
+        clsAttr.specificTypes[specificCls] ||
+        'unknownSpecificDeviceType' + specificCls
+      )
     } else {
       return 'unknownGenericDeviceType_' + genericCls
     }

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -375,36 +375,6 @@ module.exports = {
     // https://github.com/OpenZWave/open-zwave/blob/master/config/device_classes.xml
     // https://github.com/home-assistant/core/blob/dev/homeassistant/components/zwave/const.py#L196
     // 0x00: specific_type_not_used // Available in all Generic types
-    0x03: {
-      generic: 'generic_type_av_control_point',
-      specific: {
-        0x12: 'specific_type_doorbell',
-        0x04: 'specific_type_satellite_receiver',
-        0x11: 'specific_type_satellite_receiver_v2'
-      }
-    },
-    0x04: {
-      generic: 'generic_type_display',
-      specific: {
-        0x01: 'specific_type_simple_display'
-      }
-    },
-    0x40: {
-      generic: 'generic_type_entry_control',
-      specific: {
-        0x01: 'specific_type_door_lock',
-        0x02: 'specific_type_advanced_door_lock',
-        0x03: 'specific_type_secure_keypad_door_lock',
-        0x04: 'specific_type_secure_keypad_door_lock_deadbolt',
-        0x05: 'specific_type_secure_door',
-        0x06: 'specific_type_secure_gate',
-        0x07: 'specific_type_secure_barrier_addon',
-        0x08: 'specific_type_secure_barrier_open_only',
-        0x09: 'specific_type_secure_barrier_close_only',
-        0x10: 'specific_type_secure_lockbox',
-        0x11: 'specific_type_secure_keypad'
-      }
-    },
     0x01: {
       generic: 'generic_type_generic_controller',
       specific: {
@@ -413,70 +383,6 @@ module.exports = {
         0x03: 'specific_type_portable_installer_tool',
         0x04: 'specific_type_control_av',
         0x06: 'specific_type_control_simple'
-      }
-    },
-    0x31: {
-      generic: 'generic_type_meter',
-      specific: {
-        0x01: 'specific_type_simple_meter',
-        0x02: 'specific_type_adv_energy_control',
-        0x03: 'specific_type_whole_home_meter_simple'
-      }
-    },
-    0x30: {
-      generic: 'generic_type_meter_pulse',
-      specific: {}
-    },
-    0xff: {
-      generic: 'generic_type_non_interoperable',
-      specific: {}
-    },
-    0x0f: {
-      generic: 'generic_type_repeater_slave',
-      specific: {
-        0x01: 'specific_type_repeater_slave',
-        0x02: 'specific_type_virtual_node'
-      }
-    },
-    0x17: {
-      generic: 'generic_type_security_panel',
-      specific: {
-        0x01: 'specific_type_zoned_security_panel'
-      }
-    },
-    0x50: {
-      generic: 'generic_type_semi_interoperable',
-      specific: {
-        0x01: 'specific_type_energy_production'
-      }
-    },
-    0xa1: {
-      generic: 'generic_type_sensor_alarm',
-      specific: {
-        0x05: 'specific_type_adv_zensor_net_alarm_sensor',
-        0x10: 'specific_type_adv_zensor_net_smoke_sensor',
-        0x01: 'specific_type_basic_routing_alarm_sensor',
-        0x06: 'specific_type_basic_routing_smoke_sensor',
-        0x03: 'specific_type_basic_zensor_net_alarm_sensor',
-        0x08: 'specific_type_basic_zensor_net_smoke_sensor',
-        0x02: 'specific_type_routing_alarm_sensor',
-        0x07: 'specific_type_routing_smoke_sensor',
-        0x04: 'specific_type_zensor_net_alarm_sensor',
-        0x09: 'specific_type_zensor_net_smoke_sensor',
-        0x11: 'specific_type_alarm_sensor'
-      }
-    },
-    0x20: {
-      generic: 'generic_type_sensor_binary',
-      specific: {
-        0x01: 'specific_type_routing_sensor_binary'
-      }
-    },
-    0x21: {
-      generic: 'generic_type_sensor_multilevel',
-      specific: {
-        0x01: 'specific_type_routing_sensor_multilevel',
-        0x02: 'specific_type_chimney_fan'
       }
     },
     0x02: {
@@ -491,81 +397,19 @@ module.exports = {
         0x07: 'specific_type_gateway'
       }
     },
-    0x10: {
-      generic: 'generic_type_switch_binary',
+    0x03: {
+      generic: 'generic_type_av_control_point',
       specific: {
-        0x01: 'specific_type_power_switch_binary',
-        0x03: 'specific_type_scene_switch_binary',
-        0x04: 'specific_type_power_strip',
-        0x05: 'specific_type_siren',
-        0x06: 'specific_type_valve_open_close',
-        0x02: 'specific_type_color_tunable_binary',
-        0x07: 'specific_type_irrigation_controller'
+        0x01: 'specific_type_sound_switch',
+        0x04: 'specific_type_satellite_receiver',
+        0x11: 'specific_type_satellite_receiver_v2',
+        0x12: 'specific_type_doorbell'
       }
     },
-    0x11: {
-      generic: 'generic_type_switch_multilevel',
+    0x04: {
+      generic: 'generic_type_display',
       specific: {
-        0x05: 'specific_type_class_a_motor_control',
-        0x06: 'specific_type_class_b_motor_control',
-        0x07: 'specific_type_class_c_motor_control',
-        0x03: 'specific_type_motor_multiposition',
-        0x01: 'specific_type_power_switch_multilevel',
-        0x04: 'specific_type_scene_switch_multilevel',
-        0x08: 'specific_type_fan_switch',
-        0x02: 'specific_type_color_tunable_multilevel'
-      }
-    },
-    0x12: {
-      generic: 'generic_type_switch_remote',
-      specific: {
-        0x01: 'specific_type_remote_binary',
-        0x02: 'specific_type_remote_multilevel',
-        0x03: 'specific_type_remove_toggle_binary',
-        0x04: 'specific_type_remote_toggle_multilevel'
-      }
-    },
-    0x13: {
-      generic: 'generic_type_switch_toggle',
-      specific: {
-        0x01: 'specific_type_switch_toggle_binary',
-        0x02: 'specific_type_switch_toggle_multilevel'
-      }
-    },
-    0x08: {
-      generic: 'generic_type_thermostat',
-      specific: {
-        0x03: 'specific_type_setback_schedule_thermostat',
-        0x05: 'specific_type_setback_thermostat',
-        0x04: 'specific_type_setpoint_thermostat',
-        0x02: 'specific_type_thermostat_general',
-        0x06: 'specific_type_thermostat_general_v2',
-        0x01: 'specific_type_thermostat_heating'
-      }
-    },
-    0x16: {
-      generic: 'generic_type_ventilation',
-      specific: {
-        0x01: 'specific_type_residential_hrv'
-      }
-    },
-    0x09: {
-      generic: 'generic_type_windows_covering',
-      specific: {
-        0x01: 'specific_type_simple_window_covering'
-      }
-    },
-    0x15: {
-      generic: 'generic_type_zip_node',
-      specific: {
-        0x02: 'specific_type_zip_adv_node',
-        0x01: 'specific_type_zip_tun_node'
-      }
-    },
-    0x18: {
-      generic: 'generic_type_wall_controller',
-      specific: {
-        0x01: 'specific_type_basic_wall_controller'
+        0x01: 'specific_type_simple_display'
       }
     },
     0x05: {
@@ -587,6 +431,170 @@ module.exports = {
       specific: {
         0x01: 'specific_type_notification_sensor'
       }
+    },
+    0x08: {
+      generic: 'generic_type_thermostat',
+      specific: {
+        0x01: 'specific_type_thermostat_heating',
+        0x02: 'specific_type_thermostat_general',
+        0x03: 'specific_type_setback_schedule_thermostat',
+        0x04: 'specific_type_setpoint_thermostat',
+        0x05: 'specific_type_setback_thermostat',
+        0x06: 'specific_type_thermostat_general_v2'
+      }
+    },
+    0x09: {
+      generic: 'generic_type_windows_covering',
+      specific: {
+        0x01: 'specific_type_simple_window_covering'
+      }
+    },
+    0x0f: {
+      generic: 'generic_type_repeater_slave',
+      specific: {
+        0x01: 'specific_type_repeater_slave',
+        0x02: 'specific_type_virtual_node'
+      }
+    },
+    0x10: {
+      generic: 'generic_type_switch_binary',
+      specific: {
+        0x01: 'specific_type_power_switch_binary',
+        0x02: 'specific_type_color_tunable_binary',
+        0x03: 'specific_type_scene_switch_binary',
+        0x04: 'specific_type_power_strip',
+        0x05: 'specific_type_siren',
+        0x06: 'specific_type_valve_open_close',
+        0x07: 'specific_type_irrigation_controller'
+      }
+    },
+    0x11: {
+      generic: 'generic_type_switch_multilevel',
+      specific: {
+        0x01: 'specific_type_power_switch_multilevel',
+        0x02: 'specific_type_color_tunable_multilevel',
+        0x03: 'specific_type_motor_multiposition',
+        0x04: 'specific_type_scene_switch_multilevel',
+        0x05: 'specific_type_class_a_motor_control',
+        0x06: 'specific_type_class_b_motor_control',
+        0x07: 'specific_type_class_c_motor_control',
+        0x08: 'specific_type_fan_switch'
+      }
+    },
+    0x12: {
+      generic: 'generic_type_switch_remote',
+      specific: {
+        0x01: 'specific_type_remote_binary',
+        0x02: 'specific_type_remote_multilevel',
+        0x03: 'specific_type_remove_toggle_binary',
+        0x04: 'specific_type_remote_toggle_multilevel'
+      }
+    },
+    0x13: {
+      generic: 'generic_type_switch_toggle',
+      specific: {
+        0x01: 'specific_type_switch_toggle_binary',
+        0x02: 'specific_type_switch_toggle_multilevel'
+      }
+    },
+    0x14: {
+      generic: 'generic_type_zip_gateway',
+      specific: {
+        0x01: 'specific_type_zip_tun_gateway',
+        0x02: 'specific_type_zip_adv_gateway'
+      }
+    },
+    0x15: {
+      generic: 'generic_type_zip_node',
+      specific: {
+        0x01: 'specific_type_zip_tun_node',
+        0x02: 'specific_type_zip_adv_node'
+      }
+    },
+    0x16: {
+      generic: 'generic_type_ventilation',
+      specific: {
+        0x01: 'specific_type_residential_hrv'
+      }
+    },
+    0x17: {
+      generic: 'generic_type_security_panel',
+      specific: {
+        0x01: 'specific_type_zoned_security_panel'
+      }
+    },
+    0x18: {
+      generic: 'generic_type_wall_controller',
+      specific: {
+        0x01: 'specific_type_basic_wall_controller'
+      }
+    },
+    0x20: {
+      generic: 'generic_type_sensor_binary',
+      specific: {
+        0x01: 'specific_type_routing_sensor_binary'
+      }
+    },
+    0x21: {
+      generic: 'generic_type_sensor_multilevel',
+      specific: {
+        0x01: 'specific_type_routing_sensor_multilevel',
+        0x02: 'specific_type_chimney_fan'
+      }
+    },
+    0x30: {
+      generic: 'generic_type_meter_pulse',
+      specific: {}
+    },
+    0x31: {
+      generic: 'generic_type_meter',
+      specific: {
+        0x01: 'specific_type_simple_meter',
+        0x02: 'specific_type_adv_energy_control',
+        0x03: 'specific_type_whole_home_meter_simple'
+      }
+    },
+    0x40: {
+      generic: 'generic_type_entry_control',
+      specific: {
+        0x01: 'specific_type_door_lock',
+        0x02: 'specific_type_advanced_door_lock',
+        0x03: 'specific_type_secure_keypad_door_lock',
+        0x04: 'specific_type_secure_keypad_door_lock_deadbolt',
+        0x05: 'specific_type_secure_door',
+        0x06: 'specific_type_secure_gate',
+        0x07: 'specific_type_secure_barrier_addon',
+        0x08: 'specific_type_secure_barrier_open_only',
+        0x09: 'specific_type_secure_barrier_close_only',
+        0x0a: 'specific_type_secure_lockbox',
+        0x0b: 'specific_type_secure_keypad'
+      }
+    },
+    0x50: {
+      generic: 'generic_type_semi_interoperable',
+      specific: {
+        0x01: 'specific_type_energy_production'
+      }
+    },
+    0xa1: {
+      generic: 'generic_type_sensor_alarm',
+      specific: {
+        0x01: 'specific_type_basic_routing_alarm_sensor',
+        0x02: 'specific_type_routing_alarm_sensor',
+        0x03: 'specific_type_basic_zensor_net_alarm_sensor',
+        0x04: 'specific_type_zensor_net_alarm_sensor',
+        0x05: 'specific_type_adv_zensor_net_alarm_sensor',
+        0x06: 'specific_type_basic_routing_smoke_sensor',
+        0x07: 'specific_type_routing_smoke_sensor',
+        0x08: 'specific_type_basic_zensor_net_smoke_sensor',
+        0x09: 'specific_type_zensor_net_smoke_sensor',
+        0x0a: 'specific_type_adv_zensor_net_smoke_sensor',
+        0x0b: 'specific_type_alarm_sensor'
+      }
+    },
+    0xff: {
+      generic: 'generic_type_non_interoperable',
+      specific: {}
     }
   },
   genericDeviceClassAttributes (cls) {

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -372,6 +372,7 @@ module.exports = {
     return this._commandClassMap[cmd] || 'unknownClass_' + cmd
   },
   _genericDeviceClassMap: {
+    // https://github.com/OpenZWave/open-zwave/blob/master/config/device_classes.xml
     // https://github.com/home-assistant/core/blob/dev/homeassistant/components/zwave/const.py#L196
     // 0x00: specific_type_not_used // Available in all Generic types
     0x03: {

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -370,5 +370,241 @@ module.exports = {
   },
   commandClass (cmd) {
     return this._commandClassMap[cmd] || 'unknownClass_' + cmd
+  },
+  _genericDeviceClassMap: {
+    // https://github.com/home-assistant/core/blob/dev/homeassistant/components/zwave/const.py#L196
+    // 0x00: specific_type_not_used // Available in all Generic types
+    0x03: {
+      genericType: 'generic_type_av_control_point',
+      specificTypes: {
+        0x12: 'specific_type_doorbell',
+        0x04: 'specific_type_satellite_receiver',
+        0x11: 'specific_type_satellite_receiver_v2'
+      }
+    },
+    0x04: {
+      genericType: 'generic_type_display',
+      specificTypes: {
+        0x01: 'specific_type_simple_display'
+      }
+    },
+    0x40: {
+      genericType: 'generic_type_entry_control',
+      specificTypes: {
+        0x01: 'specific_type_door_lock',
+        0x02: 'specific_type_advanced_door_lock',
+        0x03: 'specific_type_secure_keypad_door_lock',
+        0x04: 'specific_type_secure_keypad_door_lock_deadbolt',
+        0x05: 'specific_type_secure_door',
+        0x06: 'specific_type_secure_gate',
+        0x07: 'specific_type_secure_barrier_addon',
+        0x08: 'specific_type_secure_barrier_open_only',
+        0x09: 'specific_type_secure_barrier_close_only',
+        0x10: 'specific_type_secure_lockbox',
+        0x11: 'specific_type_secure_keypad'
+      }
+    },
+    0x01: {
+      genericType: 'generic_type_generic_controller',
+      specificTypes: {
+        0x01: 'specific_type_portable_controller',
+        0x02: 'specific_type_portable_scene_controller',
+        0x03: 'specific_type_portable_installer_tool',
+        0x04: 'specific_type_control_av',
+        0x06: 'specific_type_control_simple'
+      }
+    },
+    0x31: {
+      genericType: 'generic_type_meter',
+      specificTypes: {
+        0x01: 'specific_type_simple_meter',
+        0x02: 'specific_type_adv_energy_control',
+        0x03: 'specific_type_whole_home_meter_simple'
+      }
+    },
+    0x30: {
+      genericType: 'generic_type_meter_pulse',
+      specificTypes: {},
+    },
+    0x0f: {
+      genericType: 'generic_type_non_interoperable',
+      specificTypes: {},
+    },
+    0x15: {
+      genericType: 'generic_type_repeater_slave',
+      specificTypes: {
+        0x01: 'specific_type_repeater_slave',
+        0x02: 'specific_type_virtual_node'
+      }
+    },
+    0x17: {
+      genericType: 'generic_type_security_panel',
+      specificTypes: {
+        0x01: 'specific_type_zoned_security_panel'
+      }
+    },
+    0x50: {
+      genericType: 'generic_type_semi_interoperable',
+      specificTypes: {
+        0x01: 'specific_type_energy_production'
+      }
+    },
+    0xa1: {
+      genericType: 'generic_type_sensor_alarm',
+      specificTypes: {
+        0x05: 'specific_type_adv_zensor_net_alarm_sensor',
+        0x10: 'specific_type_adv_zensor_net_smoke_sensor',
+        0x01: 'specific_type_basic_routing_alarm_sensor',
+        0x06: 'specific_type_basic_routing_smoke_sensor',
+        0x03: 'specific_type_basic_zensor_net_alarm_sensor',
+        0x08: 'specific_type_basic_zensor_net_smoke_sensor',
+        0x02: 'specific_type_routing_alarm_sensor',
+        0x07: 'specific_type_routing_smoke_sensor',
+        0x04: 'specific_type_zensor_net_alarm_sensor',
+        0x09: 'specific_type_zensor_net_smoke_sensor',
+        0x11: 'specific_type_alarm_sensor'
+      }
+    },
+    0x20: {
+      genericType: 'generic_type_sensor_binary',
+      specificTypes: {
+        0x01: 'specific_type_routing_sensor_binary'
+      }
+    },
+    0x21: {
+      genericType: 'generic_type_sensor_multilevel',
+      specificTypes: {
+        0x01: 'specific_type_routing_sensor_multilevel',
+        0x02: 'specific_type_chimney_fan'
+      }
+    },
+    0x02: {
+      genericType: 'generic_type_static_controller',
+      specificTypes: {
+        0x01: 'specific_type_pc_controller',
+        0x02: 'specific_type_scene_controller',
+        0x03: 'specific_type_static_installer_tool',
+        0x04: 'specific_type_set_top_box',
+        0x05: 'specific_type_sub_system_controller',
+        0x06: 'specific_type_tv',
+        0x07: 'specific_type_gateway'
+      }
+    },
+    0x10: {
+      genericType: 'generic_type_switch_binary',
+      specificTypes: {
+        0x01: 'specific_type_power_switch_binary',
+        0x03: 'specific_type_scene_switch_binary',
+        0x04: 'specific_type_power_strip',
+        0x05: 'specific_type_siren',
+        0x06: 'specific_type_valve_open_close',
+        0x02: 'specific_type_color_tunable_binary',
+        0x07: 'specific_type_irrigation_controller'
+      }
+    },
+    0x11: {
+      genericType: 'generic_type_switch_multilevel',
+      specificTypes: {
+        0x05: 'specific_type_class_a_motor_control',
+        0x06: 'specific_type_class_b_motor_control',
+        0x07: 'specific_type_class_c_motor_control',
+        0x03: 'specific_type_motor_multiposition',
+        0x01: 'specific_type_power_switch_multilevel',
+        0x04: 'specific_type_scene_switch_multilevel',
+        0x08: 'specific_type_fan_switch',
+        0x02: 'specific_type_color_tunable_multilevel'
+      }
+    },
+    0x12: {
+      genericType: 'generic_type_switch_remote',
+      specificTypes: {
+        0x01: 'specific_type_remote_binary',
+        0x02: 'specific_type_remote_multilevel',
+        0x03: 'specific_type_remove_toggle_binary',
+        0x04: 'specific_type_remote_toggle_multilevel'
+      }
+    },
+    0x13: {
+      genericType: 'generic_type_switch_toggle',
+      specificTypes: {
+        0x01: 'specific_type_switch_toggle_binary',
+        0x02: 'specific_type_switch_toggle_multilevel'
+      }
+    },
+    0x08: {
+      genericType: 'generic_type_thermostat',
+      specificTypes: {
+        0x03: 'specific_type_setback_schedule_thermostat',
+        0x05: 'specific_type_setback_thermostat',
+        0x04: 'specific_type_setpoint_thermostat',
+        0x02: 'specific_type_thermostat_general',
+        0x06: 'specific_type_thermostat_general_v2',
+        0x01: 'specific_type_thermostat_heating',
+      }
+    },
+    0x16: {
+      genericType: 'generic_type_ventilation',
+      specificTypes: {
+        0x01: 'specific_type_residential_hrv'
+      }
+    },
+    0x09: {
+      genericType: 'generic_type_windows_covering',
+      specificTypes: {
+        0x01: 'specific_type_simple_window_covering'
+      }
+    },
+    0x15: {
+      genericType: 'generic_type_zip_node',
+      specificTypes: {
+        0x02: 'specific_type_zip_adv_node',
+        0x01: 'specific_type_zip_tun_node'
+      }
+    },
+    0x18: {
+      genericType: 'generic_type_wall_controller',
+      specificTypes: {
+        0x01: 'specific_type_basic_wall_controller'
+      }
+    },
+    0x05: {
+      genericType: 'generic_type_network_extender',
+      specificTypes: {
+        0x01: 'specific_type_secure_extender'
+      }
+    },
+    0x06: {
+      genericType: 'generic_type_appliance',
+      specificTypes: {
+        0x01: 'specific_type_general_appliance',
+        0x02: 'specific_type_kitchen_appliance',
+        0x03: 'specific_type_laundry_appliance'
+      }
+    },
+    0x07: {
+      genericType: 'generic_type_sensor_notification',
+      specificTypes: {
+        0x01: 'specific_type_notification_sensor'
+      }
+    }
+  },
+  genericDeviceClassAttributes (cls) {
+    return this._genericDeviceClassMap[cls]
+  },
+  genericDeviceClass (cls) {
+    var clsAttr = this.genericDeviceClassAttributes(cls)
+    if (clsAttr) {
+      return clsAttr.genericType
+    } else {
+      return 'unknownGenericDeviceType_' + cls
+    }
+  },
+  specificDeviceClass (genericCls, specificCls) {
+    var clsAttr = this.genericDeviceClassAttributes(genericCls)
+    if (clsAttr) {
+      return clsAttr.specificTypes[specificCls] || 'unknownSpecificDeviceType' + specificCls
+    } else {
+      return 'unknownGenericDeviceType_' + genericCls
+    }
   }
 }

--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -1095,28 +1095,42 @@ Gateway.prototype.discoverValue = function (node, valueId) {
         break
       case 'switch_multilevel':
       case 'switch_toggle_multilevel':
-        // cfg = copy(hassCfg.cover_position)
-        // cfg.discovery_payload.position_open = valueId.max || 100
-        // cfg.discovery_payload.position_closed = valueId.min || 0
-        // cfg.discovery_payload.position_topic = this.mqtt.getTopic(topic)
-        // cfg.discovery_payload.set_position_topic = cfg.discovery_payload.position_topic + '/set'
         if (valueId.index === 0) {
-          // brightness level
-          const rgb = node.values['51-1-0']
-          if (rgb) {
-            cfg = copy(hassCfg.light_rgb_dimmer)
-            cfg.discovery_payload.rgb_state_topic = this.mqtt.getTopic(
-              this.valueTopic(node, rgb)
-            )
-            cfg.discovery_payload.rgb_command_topic =
-              cfg.discovery_payload.rgb_state_topic + '/set'
-            cfg.discovery_payload.brightness_state_topic = this.mqtt.getTopic(
-              topic
-            )
-            cfg.discovery_payload.brightness_command_topic =
-              cfg.discovery_payload.brightness_state_topic + '/set'
+          var specificDeviceClass = Constants.specificDeviceClass(node.generic_device_class, node.specific_device_class)
+          // Use a cover_position configuration if ...
+          if (['specific_type_class_a_motor_control',
+               'specific_type_class_b_motor_control',
+               'specific_type_class_c_motor_control',
+               'specific_type_class_motor_multiposition'].includes(specificDeviceClass)) {
+            cfg = copy(hassCfg.cover_position)
+            cfg.discovery_payload.state_topic = this.mqtt.getTopic(topic)
+            cfg.discovery_payload.command_topic = cfg.discovery_payload.state_topic + '/set'
+            cfg.discovery_payload.position_topic = this.mqtt.getTopic(topic)
+            cfg.discovery_payload.set_position_topic = cfg.discovery_payload.position_topic + '/set'
+            cfg.discovery_payload.value_template = '{{ value_json.value | round(0) }}'
+            cfg.discovery_payload.position_open = 99
+            cfg.discovery_payload.position_closed = 0
+            cfg.discovery_payload.payload_open = 99
+            cfg.discovery_payload.payload_close = 0
           } else {
-            cfg = copy(hassCfg.light_dimmer)
+            // ... otherwise use a light dimmer configuration
+            // brightness level
+            const rgb = node.values['51-1-0']
+            if (rgb) {
+              cfg = copy(hassCfg.light_rgb_dimmer)
+              cfg.discovery_payload.rgb_state_topic = this.mqtt.getTopic(
+                this.valueTopic(node, rgb)
+              )
+              cfg.discovery_payload.rgb_command_topic =
+                cfg.discovery_payload.rgb_state_topic + '/set'
+              cfg.discovery_payload.brightness_state_topic = this.mqtt.getTopic(
+                topic
+              )
+              cfg.discovery_payload.brightness_command_topic =
+                cfg.discovery_payload.brightness_state_topic + '/set'
+            } else {
+              cfg = copy(hassCfg.light_dimmer)
+            }
           }
         } else return
         break

--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -1096,18 +1096,28 @@ Gateway.prototype.discoverValue = function (node, valueId) {
       case 'switch_multilevel':
       case 'switch_toggle_multilevel':
         if (valueId.index === 0) {
-          var specificDeviceClass = Constants.specificDeviceClass(node.generic_device_class, node.specific_device_class)
+          var specificDeviceClass = Constants.specificDeviceClass(
+            node.generic_device_class,
+            node.specific_device_class
+          )
           // Use a cover_position configuration if ...
-          if (['specific_type_class_a_motor_control',
-               'specific_type_class_b_motor_control',
-               'specific_type_class_c_motor_control',
-               'specific_type_class_motor_multiposition'].includes(specificDeviceClass)) {
+          if (
+            [
+              'specific_type_class_a_motor_control',
+              'specific_type_class_b_motor_control',
+              'specific_type_class_c_motor_control',
+              'specific_type_class_motor_multiposition'
+            ].includes(specificDeviceClass)
+          ) {
             cfg = copy(hassCfg.cover_position)
             cfg.discovery_payload.state_topic = this.mqtt.getTopic(topic)
-            cfg.discovery_payload.command_topic = cfg.discovery_payload.state_topic + '/set'
+            cfg.discovery_payload.command_topic =
+              cfg.discovery_payload.state_topic + '/set'
             cfg.discovery_payload.position_topic = this.mqtt.getTopic(topic)
-            cfg.discovery_payload.set_position_topic = cfg.discovery_payload.position_topic + '/set'
-            cfg.discovery_payload.value_template = '{{ value_json.value | round(0) }}'
+            cfg.discovery_payload.set_position_topic =
+              cfg.discovery_payload.position_topic + '/set'
+            cfg.discovery_payload.value_template =
+              '{{ value_json.value | round(0) }}'
             cfg.discovery_payload.position_open = 99
             cfg.discovery_payload.position_closed = 0
             cfg.discovery_payload.payload_open = 99

--- a/lib/ZwaveClient.js
+++ b/lib/ZwaveClient.js
@@ -906,6 +906,10 @@ ZwaveClient.prototype.initNode = function (ozwnode, nodeinfo) {
   var deviceID = getDeviceID(ozwnode)
   ozwnode.device_id = deviceID
 
+  ozwnode.basic_device_class = this.client.getNodeBasic(nodeid)
+  ozwnode.generic_device_class = this.client.getNodeGeneric(nodeid)
+  ozwnode.specific_device_class = this.client.getNodeSpecific(nodeid)
+
   // if scan is complete update node groups (for nodes added 'on fly')
   if (this.scanComplete) {
     this.getGroups(nodeid)

--- a/test/lib/Constants.test.js
+++ b/test/lib/Constants.test.js
@@ -129,4 +129,40 @@ describe('#Constants', () => {
     it('known', () => mod.commandClass(1).should.equal('foo'))
     it('unknown', () => mod.commandClass(3).should.equal('unknownClass_3'))
   })
+  describe('#genericDeviceClass()', () => {
+    let map
+    before(() => {
+      map = mod._genericDeviceClassMap
+      mod._genericDeviceClassMap = {
+        1: { generic: 'foo', specific: { 1: 'bar', 2: 'baz' } }
+      }
+    })
+    after(() => {
+      mod._genericDeviceClassMap = map
+    })
+    it('known generic type', () =>
+      mod.genericDeviceClass(1).should.equal('foo'))
+    it('unknown generic type', () =>
+      mod.genericDeviceClass(3).should.equal('unknownGenericDeviceType_3'))
+  })
+  describe('#specificDeviceClass()', () => {
+    let map
+    before(() => {
+      map = mod._genericDeviceClassMap
+      mod._genericDeviceClassMap = {
+        1: { generic: 'foo', specific: { 1: 'bar', 2: 'baz' } }
+      }
+    })
+    after(() => {
+      mod._genericDeviceClassMap = map
+    })
+    it('known specific type', () =>
+      mod.specificDeviceClass(1, 1).should.equal('bar'))
+    it('unknown specific type', () =>
+      mod.specificDeviceClass(1, 3).should.equal('unknownSpecificDeviceType_3'))
+    it('unknown generic type 1', () =>
+      mod.specificDeviceClass(2, 1).should.equal('unknownGenericDeviceType_2'))
+    it('unknown generic type 2', () =>
+      mod.specificDeviceClass(2, 3).should.equal('unknownGenericDeviceType_2'))
+  })
 })


### PR DESCRIPTION
The main goal of this PR is to fix #329 

There are two main changes:
1. in the Zwave client, adding to the zwave nodes the basic, generic and specific device class as provided by the openzwave stack. I also added the constants for all the generic/specific classes.
2. in the Gateway, adapting the hass discovery logic to use the cover_position entity instead of the light_dimmer

I tested it with the Aeotec NanoShutter: https://github.com/OpenZWave/open-zwave/blob/master/config/aeotec/zw141.xml

This **only** solves discovery of the "cover position".
Looking at my Aeotec device I see many other controls that could be discovered in a more "specific" way. Unfortunately I don't know if this kind of device is more or less standardized or if any vendor comes up with different sets of commands and controls.
In my case, for example, to get the best behaviour I have to combine the cover_position entity with a "cover template" integration in Homeassistant.

Let me know if you want unit tests for these changes. I see there aren't many at the moment and I'm not sure what's your preferred approach.