### PR TITLE
fix: implement more environment variables for configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ After a [discussion](https://github.com/OpenZWave/Zwave2Mqtt/issues/201) with Op
     - [Mesh](#mesh)
     - [Debug](#debug)
   - [Health check endpoints](#health-check-endpoints)
+  - [Environment variables](#environment-variables)
   - [:question: FAQ](#-faq)
   - [:pray: Thanks](#-thanks)
   - [:pencil: TODOs](#-todos)
@@ -803,6 +804,17 @@ All nodes with command class `thermostat_setpoint` and value `heating` will be s
 Remember to add the header: `Accept: text/plain` to your request.
 
 Example: `curl localhost:8091/health/zwave -H "Accept: text/plain"`
+
+## Environment variables
+
+_**Note**: Each one of the following environment variables corresponds to their respective options in the UI settings and options saved in the UI take presence over these environment variables._
+
+- `OZW_NETWORK_KEY`
+- `OZW_SAVE_CONFIG`
+- `OZW_POLL_INTERVAL`
+- `OZW_AUTO_UPDATE_CONFIG`
+- `OZW_CONFIG_PATH`
+- `OZW_ASSUME_AWAKE`
 
 ## :question: FAQ
 

--- a/lib/ZwaveClient.js
+++ b/lib/ZwaveClient.js
@@ -135,7 +135,10 @@ async function init (cfg, socket) {
 
   this.closed = false
   this.scenes = jsonStore.get(store.scenes)
-
+  
+  cfg.saveConfig = cfg.saveConfig || process.env.OZW_SAVE_CONFIG
+  cfg.autoUpdateConfig = cfg.autoUpdateConfig || process.env.OZW_AUTO_UPDATE_CONFIG
+  
   // Full option list: https://github.com/OpenZWave/open-zwave/wiki/Config-Options
   var options = {
     Logging: cfg.logging,
@@ -143,11 +146,11 @@ async function init (cfg, socket) {
     QueueLogLevel: cfg.logging ? 8 : 6,
     UserPath: storeDir, // where to store config files
     DriverMaxAttempts: 9999,
-    SaveConfiguration: Boolean(cfg.saveConfig || process.env.OZW_SAVE_CONFIG),
+    SaveConfiguration: Boolean(cfg.saveConfig),
     //  RetryTimeout: 10000,
     //  IntervalBetweenPolls: true,
     PollInterval: cfg.pollInterval || process.env.OZW_POLL_INTERVAL,
-    AutoUpdateConfigFile: Boolean(cfg.autoUpdateConfig || process.env.OZW_AUTO_UPDATE_DB)
+    AutoUpdateConfigFile: Boolean(cfg.autoUpdateConfig)
     // SuppressValueRefresh: true,
   }
 

--- a/lib/ZwaveClient.js
+++ b/lib/ZwaveClient.js
@@ -135,10 +135,10 @@ async function init (cfg, socket) {
 
   this.closed = false
   this.scenes = jsonStore.get(store.scenes)
-  
+
   cfg.saveConfig = cfg.saveConfig || process.env.OZW_SAVE_CONFIG
   cfg.autoUpdateConfig = cfg.autoUpdateConfig || process.env.OZW_AUTO_UPDATE_CONFIG
-  
+
   // Full option list: https://github.com/OpenZWave/open-zwave/wiki/Config-Options
   var options = {
     Logging: cfg.logging,

--- a/lib/ZwaveClient.js
+++ b/lib/ZwaveClient.js
@@ -137,7 +137,8 @@ async function init (cfg, socket) {
   this.scenes = jsonStore.get(store.scenes)
 
   cfg.saveConfig = cfg.saveConfig || process.env.OZW_SAVE_CONFIG
-  cfg.autoUpdateConfig = cfg.autoUpdateConfig || process.env.OZW_AUTO_UPDATE_CONFIG
+  cfg.autoUpdateConfig =
+    cfg.autoUpdateConfig || process.env.OZW_AUTO_UPDATE_CONFIG
 
   // Full option list: https://github.com/OpenZWave/open-zwave/wiki/Config-Options
   var options = {

--- a/lib/ZwaveClient.js
+++ b/lib/ZwaveClient.js
@@ -143,11 +143,11 @@ async function init (cfg, socket) {
     QueueLogLevel: cfg.logging ? 8 : 6,
     UserPath: storeDir, // where to store config files
     DriverMaxAttempts: 9999,
-    SaveConfiguration: Boolean(cfg.saveConfig),
+    SaveConfiguration: Boolean(cfg.saveConfig || process.env.OZW_SAVE_CONFIG),
     //  RetryTimeout: 10000,
     //  IntervalBetweenPolls: true,
-    PollInterval: cfg.pollInterval,
-    AutoUpdateConfigFile: Boolean(cfg.autoUpdateConfig)
+    PollInterval: cfg.pollInterval || process.env.OZW_POLL_INTERVAL,
+    AutoUpdateConfigFile: Boolean(cfg.autoUpdateConfig || process.env.OZW_AUTO_UPDATE_DB)
     // SuppressValueRefresh: true,
   }
 
@@ -158,11 +158,11 @@ async function init (cfg, socket) {
   }
 
   if (cfg.configPath) {
-    options.ConfigPath = cfg.configPath
+    options.ConfigPath = cfg.configPath || process.env.OZW_CONFIG_PATH
   }
 
   if (cfg.assumeAwake) {
-    options.AssumeAwake = cfg.assumeAwake
+    options.AssumeAwake = cfg.assumeAwake || process.env.OZW_ASSUME_AWAKE
   }
 
   if (cfg.options) {


### PR DESCRIPTION
Allows more zwave settings to be declared via environment variables

- `OZW_SAVE_CONFIG`
- `OZW_POLL_INTERVAL`
- `OZW_AUTO_UPDATE_CONFIG`
- `OZW_CONFIG_PATH`
- `OZW_ASSUME_AWAKE`