### PR TITLE
feat: Update last active on value changes

### DIFF
--- a/lib/ZwaveClient.js
+++ b/lib/ZwaveClient.js
@@ -505,7 +505,6 @@ function nodeReady (nodeid, nodeinfo) {
 function valueChanged (nodeid, comclass, valueId) {
   var ozwnode = this.nodes[nodeid]
   var value_id = getValueID(valueId)
-  var triggerStatusUpdate = false
 
   parseValue(valueId)
 
@@ -522,20 +521,13 @@ function valueChanged (nodeid, comclass, valueId) {
     }
     // update cache
     ozwnode.values[value_id] = valueId
-
     // update last active timestamp
     ozwnode.lastActive = Date.now()
-    triggerStatusUpdate = true
   }
 
   // check if node is added as secure node
   if (comclass === 0x98 && valueId.index === 0) {
     ozwnode.secure = valueId.value
-    triggerStatusUpdate = true
-  }
-
-  // trigger a status update if something important has changed
-  if (triggerStatusUpdate) {
     this.emit('nodeStatus', ozwnode)
   }
 }

--- a/lib/ZwaveClient.js
+++ b/lib/ZwaveClient.js
@@ -505,6 +505,7 @@ function nodeReady (nodeid, nodeinfo) {
 function valueChanged (nodeid, comclass, valueId) {
   var ozwnode = this.nodes[nodeid]
   var value_id = getValueID(valueId)
+  var triggerStatusUpdate = false
 
   parseValue(valueId)
 
@@ -521,11 +522,20 @@ function valueChanged (nodeid, comclass, valueId) {
     }
     // update cache
     ozwnode.values[value_id] = valueId
+
+    // update last active timestamp
+    ozwnode.lastActive = Date.now()
+    triggerStatusUpdate = true
   }
 
   // check if node is added as secure node
   if (comclass === 0x98 && valueId.index === 0) {
     ozwnode.secure = valueId.value
+    triggerStatusUpdate = true
+  }
+
+  // trigger a status update if something important has changed
+  if (triggerStatusUpdate) {
     this.emit('nodeStatus', ozwnode)
   }
 }


### PR DESCRIPTION
This updates the last active timestamp not only on status changes but on every value change a node reports.
I introduced a triggerStatusUpdate variable to prevent multiple updates within valueChanged().
Has been tested successfully on my local setup.

closes #490