### PR TITLE
Add node table column filter

### DIFF
--- a/hass/devices.js
+++ b/hass/devices.js
@@ -345,5 +345,6 @@ module.exports = {
   '328-2-3': [SPIRIT_ZWAVE_PLUS],
   '328-3-3': [SPIRIT_ZWAVE_PLUS],
   '345-82-3': [COVER], // Qubino flush shutter
-  '622-23089-17235': [COVER] // Graber/Bali/Spring Fashion Covers
+  '622-23089-17235': [COVER], // Graber/Bali/Spring Fashion Covers
+  '881-21-2': [SPIRIT_ZWAVE_PLUS] // Eurotronic Spirit / Aeotec ZWA021
 }

--- a/lib/ZwaveClient.js
+++ b/lib/ZwaveClient.js
@@ -521,6 +521,8 @@ function valueChanged (nodeid, comclass, valueId) {
     }
     // update cache
     ozwnode.values[value_id] = valueId
+    // update last active timestamp
+    ozwnode.lastActive = Date.now()
   }
 
   // check if node is added as secure node

--- a/src/App.vue
+++ b/src/App.vue
@@ -83,7 +83,7 @@
       v-model="snackbar"
     >
       {{ snackbarText }}
-      <v-btn text @click.native="snackbar = false">Close</v-btn>
+      <v-btn text @click="snackbar = false">Close</v-btn>
     </v-snackbar>
   </v-app>
 </template>

--- a/src/components/Confirm.vue
+++ b/src/components/Confirm.vue
@@ -12,8 +12,8 @@
       <v-card-text v-show="!!message" class="pa-4">{{ message }}</v-card-text>
       <v-card-actions class="pt-0">
         <v-spacer></v-spacer>
-        <v-btn @click.native="agree" text :color="options.color">Yes</v-btn>
-        <v-btn @click.native="cancel" text>Cancel</v-btn>
+        <v-btn @click="agree" text :color="options.color">Yes</v-btn>
+        <v-btn @click="cancel" text>Cancel</v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>

--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -732,20 +732,10 @@ export default {
       val || this.closeDialog()
     },
     newName (val) {
-      var match = val
-        ? val.match(/[a-zA-Z\u00C0-\u024F\u1E00-\u1EFF0-9_-]+/g)
-        : [val]
-
-      this.nameError =
-        match[0] !== val ? 'Only a-zA-Z0-9_- chars are allowed' : null
+      this.nameError = this.validateTopic(val)
     },
     newLoc (val) {
-      var match = val
-        ? val.match(/[a-zA-Z\u00C0-\u024F\u1E00-\u1EFF0-9_-]+/g)
-        : [val]
-
-      this.locError =
-        match[0] !== val ? 'Only a-zA-Z0-9_- chars are allowed' : null
+      this.locError = this.validateTopic(val)
     },
     selectedNode () {
       if (this.selectedNode) {
@@ -1020,6 +1010,13 @@ export default {
         'status': (value, search, item) => this.filterNodesStringCol(value, search, item, this.headers[6]),
         'lastActive': (value, search, item) => this.filterNodesDateCol(value, search, item, this.headers[7]),
       }
+    },
+    validateTopic (name) {
+      var match = name
+        ? name.match(/[/a-zA-Z\u00C0-\u024F\u1E00-\u1EFF0-9_-]+/g)
+        : [name]
+
+      return match[0] !== name ? 'Only a-zA-Z0-9_- chars are allowed' : null
     },
     selectNode (item) {
       if (!item) return

--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -1015,6 +1015,72 @@ export default {
 
       return match[0] !== name ? 'Only a-zA-Z0-9_- chars are allowed' : null
     },
+    filterNodesByList (value, search, item, list) {
+      // Exclude not contained in selected list elements:
+      if (list !== null &&
+            list.length > 0 &&
+            !list.includes(value)
+      ) return false
+      return true
+    },
+    filterNodesStringCol (value, search, item, header) {
+      if (
+        header.search !== undefined &&
+        header.search !== null &&
+        typeof value === 'string') {
+          let i = value.toString().toLocaleLowerCase().indexOf(header.search.toLocaleLowerCase())
+          if (i === -1) return false
+      }
+      if (!this.filterNodesByList(value, search, item, header.filterInfo.list)) return false
+      return true
+    },
+    filterNodesNumberCol (value, search, item, header) {
+      let fi = header.filterInfo
+      if (
+        fi.min !== undefined &&
+        fi.min !== null &&
+        typeof value === 'number' &&
+        value < parseInt(fi.min)
+      ) return false
+      if (
+        fi.max !== undefined &&
+        fi.max !== null &&
+        typeof value === 'number' &&
+        value > parseInt(fi.max)
+      ) return false
+      if (!this.filterNodesByList(value, search, item, header.filterInfo.list)) return false
+      return true
+    },
+    filterNodesDateCol (value, search, item, header) {
+      return true
+      let fi = header.filterInfo
+      if (
+        fi.min !== undefined &&
+        fi.min !== null &&
+        typeof value === 'date' &&
+        value < new Date(fi.min)
+      ) return false
+      if (
+        fi.max !== undefined &&
+        fi.max !== null &&
+        typeof value === 'date' &&
+        value > new Date(fi.max)
+      ) return false
+      if (!this.filterNodesByList(value, search, item, header.filterInfo.list)) return false
+      return true
+    },
+    filterNodeCols () {
+      return {
+        'node_id': (value, search, item) => this.filterNodesNumberCol(value, search, item, this.headers[0]),
+        'type': (value, search, item) => this.filterNodesStringCol(value, search, item, this.headers[1]),
+        'product': (value, search, item) => this.filterNodesStringCol(value, search, item, this.headers[2]),
+        'name': (value, search, item) => this.filterNodesStringCol(value, search, item, this.headers[3]),
+        'loc': (value, search, item) => this.filterNodesStringCol(value, search, item, this.headers[4]),
+        'secure': (value, search, item) => this.filterNodesStringCol(value, search, item, this.headers[5]),
+        'status': (value, search, item) => this.filterNodesStringCol(value, search, item, this.headers[6]),
+        'lastActive': (value, search, item) => this.filterNodesDateCol(value, search, item, this.headers[7]),
+      }
+    },
     selectNode (item) {
       if (!item) return
 

--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -993,7 +993,6 @@ export default {
       return true
     },
     filterNodesDateCol (value, search, item, header) {
-      return true
       let fi = header.filterInfo
       if (
         fi.min !== undefined &&

--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -47,7 +47,7 @@
             </v-flex>
 
             <v-flex xs12 sm6 md3 align-self-center>
-              <v-btn icon @click.native="importConfiguration">
+              <v-btn icon @click="importConfiguration">
                 <v-tooltip bottom>
                   <template v-slot:activator="{ on }">
                     <v-icon dark color="primary" v-on="on">file_upload</v-icon>
@@ -55,7 +55,7 @@
                   <span>Import nodes.json Configuration</span>
                 </v-tooltip>
               </v-btn>
-              <v-btn icon @click.native="exportConfiguration">
+              <v-btn icon @click="exportConfiguration">
                 <v-tooltip bottom>
                   <template v-slot:activator="{ on }">
                     <v-icon dark color="primary" v-on="on"
@@ -337,25 +337,22 @@
                       <v-btn
                         color="blue darken-1"
                         text
-                        @click.native="storeDevices(false)"
+                        @click="storeDevices(false)"
                         >Store</v-btn
                       >
                       <v-btn
                         color="red darken-1"
                         text
-                        @click.native="storeDevices(true)"
+                        @click="storeDevices(true)"
                         >Remove Store</v-btn
                       >
-                      <v-btn
-                        color="green darken-1"
-                        text
-                        @click.native="rediscoverNode"
+                      <v-btn color="green darken-1" text @click="rediscoverNode"
                         >Rediscover Node</v-btn
                       >
                       <v-btn
                         color="yellow darken-1"
                         text
-                        @click.native="disableDiscovery"
+                        @click="disableDiscovery"
                         >Disable Discovery</v-btn
                       >
 
@@ -395,7 +392,7 @@
                         color="blue darken-1"
                         :disabled="errorDevice"
                         text
-                        @click.native="addDevice"
+                        @click="addDevice"
                         >Add</v-btn
                       >
                       <v-btn
@@ -403,7 +400,7 @@
                         color="blue darken-1"
                         :disabled="errorDevice"
                         text
-                        @click.native="updateDevice"
+                        @click="updateDevice"
                         >Update</v-btn
                       >
                       <v-btn
@@ -411,7 +408,7 @@
                         color="green darken-1"
                         :disabled="errorDevice"
                         text
-                        @click.native="rediscoverDevice"
+                        @click="rediscoverDevice"
                         >Rediscover</v-btn
                       >
                       <v-btn
@@ -419,7 +416,7 @@
                         color="red darken-1"
                         :disabled="errorDevice"
                         text
-                        @click.native="deleteDevice"
+                        @click="deleteDevice"
                         >Delete</v-btn
                       >
                       <v-textarea
@@ -505,7 +502,7 @@
                     <v-btn
                       rounded
                       color="primary"
-                      @click.native="addAssociation"
+                      @click="addAssociation"
                       dark
                       class="mb-2"
                       >Add</v-btn
@@ -513,7 +510,7 @@
                     <v-btn
                       rounded
                       color="primary"
-                      @click.native="removeAssociation"
+                      @click="removeAssociation"
                       dark
                       class="mb-2"
                       >Remove</v-btn
@@ -528,11 +525,11 @@
               <v-container grid-list-md>
                 <v-layout wrap>
                   <v-flex xs12>
-                    <v-btn text @click.native="importScenes">
+                    <v-btn text @click="importScenes">
                       Import
                       <v-icon right dark color="primary">file_upload</v-icon>
                     </v-btn>
-                    <v-btn text @click.native="exportScenes">
+                    <v-btn text @click="exportScenes">
                       Export
                       <v-icon right dark color="primary">file_download</v-icon>
                     </v-btn>

--- a/src/components/custom/file-input.vue
+++ b/src/components/custom/file-input.vue
@@ -6,7 +6,7 @@
       v-model="filename"
       :label="label.toUpperCase()"
       :required="required"
-      @click.native="onFocus"
+      @click="onFocus"
       :rules="rules"
       :disabled="disabled"
       ref="fileTextField"

--- a/src/components/custom/table-col-filter.vue
+++ b/src/components/custom/table-col-filter.vue
@@ -1,0 +1,108 @@
+<template>
+  <v-menu
+    :value="showFilterOptions"
+    :close-on-content-click="false"
+    @suspend="showFilterOptions=false"
+  >
+    <template v-slot:activator="{ on, attrs }">
+      <v-icon small v-on:click="showFilterOptions=true"
+        v-bind="attrs"
+        v-on="on"
+      >
+        {{ hasColFilter(header) ? 'filter_alt' : 'filter_list' }}
+      </v-icon>
+    </template>
+    <v-card>
+      <v-card-text>
+        <v-text-field ref="search" v-if="header.filterInfo.type=='string'" label="Contains" v-model="header.search" @change="showFilterOptions=false" @show="$refs.search.$el.focus()"></v-text-field>
+        <v-row>
+          <v-col>
+            <v-text-field v-if="header.filterInfo.type=='number'" type="number" label="Min" v-model="header.filterInfo.min"></v-text-field>
+          </v-col>
+          <v-col>
+            <v-text-field v-if="header.filterInfo.type=='number'" type="number" label="Max" v-model="header.filterInfo.max"></v-text-field>
+          </v-col>
+          <v-col>
+            <v-text-field v-if="header.filterInfo.type=='date'" type="datetime-local" label="Min" v-model="header.filterInfo.min"></v-text-field>
+          </v-col>
+          <v-col>
+            <v-text-field v-if="header.filterInfo.type=='date'" type="datetime-local" label="Max" v-model="header.filterInfo.max"></v-text-field>
+          </v-col>
+        </v-row>
+        Items
+        <v-item-group multiple v-model="header.filterInfo.list">
+          <v-item
+            v-for="item in nodeColumnValueList(header)"
+            :key="item"
+            :value="item"
+            v-slot:default="{ active, toggle }"
+          >
+            <v-chip
+              active-class="blue--text"
+              :input-value="active"
+              @click="toggle"
+            >
+              {{ item }}
+            </v-chip>
+          </v-item>
+        </v-item-group>
+      </v-card-text>
+      <v-card-actions>
+        <v-btn @click="resetColFilter(header);showFilterOptions=false">Clear</v-btn>
+        <v-btn color="primary" @click="showFilterOptions=false">Ok</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-menu>
+</template>
+
+<script>
+export default {
+  props: {
+    data: {
+      type: Array,
+    },
+    headers: {
+      type: Array,
+    },
+    header: {
+      type: Object,
+    },
+  },
+  data () {
+    return {
+      showFilterOptions: false,
+    }
+  },
+  methods: {
+    nodeColumnValueList(header) {
+      let values = this.data.map(v => v[header.value]).filter(
+        v => {
+          if (
+            header.search !== undefined &&
+            header.search !== null &&
+            typeof v === 'string' &&
+            (
+              v === '' ||
+              v.toString().toLocaleLowerCase().indexOf(header.search.toLocaleLowerCase()) === -1
+            )
+          ) return false
+          return true
+        }
+      )
+      return [...new Set(values)];
+    },
+    hasColFilter (header) {
+      return (header.search != null && header.search != '')
+        || (header.filterInfo.list.length > 0)
+        || (header.filterInfo.min != null)
+        || (header.filterInfo.max != null)
+    },
+    resetColFilter (header) {
+      header.search = null
+      if (header.filterInfo && header.filterInfo.list) header.filterInfo.list = []
+      if (header.filterInfo && header.filterInfo.min) header.filterInfo.min = null
+      if (header.filterInfo && header.filterInfo.max) header.filterInfo.max = null
+    },
+  }
+}
+</script>

--- a/src/components/custom/table-col-filter.vue
+++ b/src/components/custom/table-col-filter.vue
@@ -15,21 +15,16 @@
     <v-card>
       <v-card-text>
         <v-text-field ref="search" v-if="header.filterInfo.type=='string'" label="Contains" v-model="header.search" @change="showFilterOptions=false" @show="$refs.search.$el.focus()"></v-text-field>
-        <v-row>
+        <v-row v-if="header.filterInfo.type=='number' || header.filterInfo.type=='date'">
           <v-col>
             <v-text-field v-if="header.filterInfo.type=='number'" type="number" label="Min" v-model="header.filterInfo.min"></v-text-field>
-          </v-col>
-          <v-col>
-            <v-text-field v-if="header.filterInfo.type=='number'" type="number" label="Max" v-model="header.filterInfo.max"></v-text-field>
-          </v-col>
-          <v-col>
             <v-text-field v-if="header.filterInfo.type=='date'" type="datetime-local" label="Min" v-model="header.filterInfo.min"></v-text-field>
           </v-col>
           <v-col>
+            <v-text-field v-if="header.filterInfo.type=='number'" type="number" label="Max" v-model="header.filterInfo.max"></v-text-field>
             <v-text-field v-if="header.filterInfo.type=='date'" type="datetime-local" label="Max" v-model="header.filterInfo.max"></v-text-field>
           </v-col>
         </v-row>
-        Items
         <v-item-group multiple v-model="header.filterInfo.list">
           <v-item
             v-for="item in nodeColumnValueList(header)"


### PR DESCRIPTION
This PR adds the possibility to filter nodes by their column values which is helpful on a large number nodes.
Filtering can done by searching for a string in the column values or by selecting available values.

**Screenshots:**

Icons have been added to activate the filter options and to indicate a filtered column:
![image](https://user-images.githubusercontent.com/207989/96387624-c48f5000-11a3-11eb-8e61-195ef15a80f8.png)

Example with a substring text filter:
![image](https://user-images.githubusercontent.com/207989/96387600-9ad62900-11a3-11eb-901a-4852d9144651.png)

Example with a selected value from a list of values:
![image](https://user-images.githubusercontent.com/207989/96387572-5e0a3200-11a3-11eb-87d0-ae2e56ac1b2a.png)

It's already working very well but there are some things that may be improved, e.g.:
* Columns with type number and date may be filtered using a min and max filter (it is already prepared, but needs some more work)
* Layout of list selection may not work well with a large number of different values (check out wrapping and scrolling of items)
* Add a "Select all" or "Clear all" action for list items
* Optimize the code to be more efficient