### PR TITLE
feat: Add node table filter

### DIFF
--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -689,6 +689,7 @@ export default {
       debugActive: false,
       selectedScene: null,
       cnt_status: 'Unknown',
+      nodeTableItems: 10,
       newScene: '',
       scene_values: [],
       dialogValue: false,

--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -633,9 +633,6 @@ export default {
     }
   },
   watch: {
-    nodeTableItems (val) {
-      localStorage.setItem('nodes_itemsPerPage', val)
-    },
     dialogValue (val) {
       val || this.closeDialog()
     },
@@ -688,7 +685,6 @@ export default {
       debugActive: false,
       selectedScene: null,
       cnt_status: 'Unknown',
-      nodeTableItems: 10,
       newScene: '',
       scene_values: [],
       dialogValue: false,
@@ -1313,10 +1309,6 @@ export default {
   },
   mounted () {
     var self = this
-
-    const itemsPerPage = parseInt(localStorage.getItem('nodes_itemsPerPage'))
-
-    this.nodeTableItems = !isNaN(itemsPerPage) ? itemsPerPage : 10
 
     this.socket.on(this.socketEvents.controller, data => {
       self.cnt_status = data.help

--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -681,7 +681,6 @@ export default {
       nodes: [],
       scenes: [],
       debug: [],
-      filters: {},
       homeid: '',
       homeHex: '',
       ozwVersion: '',

--- a/src/components/nodes-table/filter-options.vue
+++ b/src/components/nodes-table/filter-options.vue
@@ -69,31 +69,33 @@
 export default {
   props: {
     value: {
-      type: Object,
+      type: Object
     },
     items: {
-      type: Array,
+      type: Array
     }
   },
   data () {
     return {
-      show: false,
+      show: false
     }
   },
   computed: {
     hasFilter () {
       return this.value !== undefined && this.value !== null &&
-        ((this.value.search !== undefined && this.value.search !== null && this.value.search !== '')
-        || (this.value.selections !== undefined && this.value.selections !== null && this.value.selections.length > 0)
-        || (this.value.min !== undefined && this.value.min !== null)
-        || (this.value.max !== undefined && this.value.max !== null))
-    },
+        (
+          (this.value.search !== undefined && this.value.search !== null && this.value.search !== '') ||
+          (this.value.selections !== undefined && this.value.selections !== null && this.value.selections.length > 0) ||
+          (this.value.min !== undefined && this.value.min !== null) ||
+          (this.value.max !== undefined && this.value.max !== null)
+        )
+    }
   },
   methods: {
-    showOptions() {
+    showOptions () {
       this.show = true
     },
-    hideOptions() {
+    hideOptions () {
       this.show = false
     },
     clearFilter () {

--- a/src/components/nodes-table/filter-options.vue
+++ b/src/components/nodes-table/filter-options.vue
@@ -1,11 +1,9 @@
 <template>
-  <v-menu
-    :value="show"
-    :close-on-content-click="false"
-    :offset-y="true"
-  >
+  <v-menu :value="show" :close-on-content-click="false" :offset-y="true">
     <template v-slot:activator="{ on, attrs }">
-      <v-icon small v-on:click="showOptions()"
+      <v-icon
+        small
+        v-on:click="showOptions()"
         v-bind="attrs"
         v-on="on"
         title="Filter options..."
@@ -16,7 +14,7 @@
     <v-card>
       <v-icon small v-on:click="hideOptions()" right>close</v-icon>
       <v-card-text>
-        <v-row v-if="value && value.type=='string'">
+        <v-row v-if="value && value.type == 'string'">
           <v-col>
             <v-text-field
               ref="search"
@@ -28,21 +26,43 @@
             ></v-text-field>
           </v-col>
         </v-row>
-        <v-row v-if="value && value.type=='number'">
+        <v-row v-if="value && value.type == 'number'">
           <v-col>
-            <v-text-field type="number" label="Min" v-model="value.min" clearable></v-text-field>
+            <v-text-field
+              type="number"
+              label="Min"
+              v-model="value.min"
+              clearable
+            ></v-text-field>
           </v-col>
           <v-col>
-            <v-text-field type="number" label="Max" v-model="value.max" clearable></v-text-field>
+            <v-text-field
+              type="number"
+              label="Max"
+              v-model="value.max"
+              clearable
+            ></v-text-field>
           </v-col>
         </v-row>
-        <v-row v-if="value && value.type=='date'">
+        <v-row v-if="value && value.type == 'date'">
           <v-col>
-            <v-text-field type="datetime-local" label="From" v-model="value.min" clearable></v-text-field>
-            <v-text-field type="datetime-local" label="Until" v-model="value.max" clearable></v-text-field>
+            <v-text-field
+              type="datetime-local"
+              label="From"
+              v-model="value.min"
+              clearable
+            ></v-text-field>
+            <v-text-field
+              type="datetime-local"
+              label="Until"
+              v-model="value.max"
+              clearable
+            ></v-text-field>
           </v-col>
         </v-row>
-        <v-row v-if="value && (value.type=='string' || value.type=='number')">
+        <v-row
+          v-if="value && (value.type == 'string' || value.type == 'number')"
+        >
           <v-col>
             <v-select
               v-model="value.selections"
@@ -56,9 +76,13 @@
             ></v-select>
           </v-col>
         </v-row>
-        <v-row v-if="value && value.type=='boolean'">
+        <v-row v-if="value && value.type == 'boolean'">
           <v-col>
-            <v-checkbox :indeterminate="value.bool == undefined || value.bool == null" v-model="value.bool" label="Boolean value"></v-checkbox>
+            <v-checkbox
+              :indeterminate="value.bool == undefined || value.bool == null"
+              v-model="value.bool"
+              label="Boolean value"
+            ></v-checkbox>
           </v-col>
         </v-row>
       </v-card-text>
@@ -87,14 +111,19 @@ export default {
   },
   computed: {
     hasFilter () {
-      return this.value !== undefined && this.value !== null &&
-        (
-          (this.value.search !== undefined && this.value.search !== null && this.value.search !== '') ||
-          (this.value.selections !== undefined && this.value.selections !== null && this.value.selections.length > 0) ||
+      return (
+        this.value !== undefined &&
+        this.value !== null &&
+        ((this.value.search !== undefined &&
+          this.value.search !== null &&
+          this.value.search !== '') ||
+          (this.value.selections !== undefined &&
+            this.value.selections !== null &&
+            this.value.selections.length > 0) ||
           (this.value.min !== undefined && this.value.min !== null) ||
           (this.value.max !== undefined && this.value.max !== null) ||
-          (this.value.bool !== undefined && this.value.bool !== null)
-        )
+          (this.value.bool !== undefined && this.value.bool !== null))
+      )
     }
   },
   methods: {

--- a/src/components/nodes-table/filter-options.vue
+++ b/src/components/nodes-table/filter-options.vue
@@ -42,7 +42,7 @@
             <v-text-field type="datetime-local" label="Until" v-model="value.max" clearable></v-text-field>
           </v-col>
         </v-row>
-        <v-row v-if="value && (value.type=='string' || value.type=='number' || value.type=='boolean')">
+        <v-row v-if="value && (value.type=='string' || value.type=='number')">
           <v-col>
             <v-select
               v-model="value.selections"
@@ -54,6 +54,11 @@
               dense
               multiple
             ></v-select>
+          </v-col>
+        </v-row>
+        <v-row v-if="value && value.type=='boolean'">
+          <v-col>
+            <v-checkbox :indeterminate="value.bool == undefined || value.bool == null" v-model="value.bool" label="Boolean value"></v-checkbox>
           </v-col>
         </v-row>
       </v-card-text>
@@ -87,7 +92,8 @@ export default {
           (this.value.search !== undefined && this.value.search !== null && this.value.search !== '') ||
           (this.value.selections !== undefined && this.value.selections !== null && this.value.selections.length > 0) ||
           (this.value.min !== undefined && this.value.min !== null) ||
-          (this.value.max !== undefined && this.value.max !== null)
+          (this.value.max !== undefined && this.value.max !== null) ||
+          (this.value.bool !== undefined && this.value.bool !== null)
         )
     }
   },
@@ -103,6 +109,7 @@ export default {
       this.value.selections = []
       this.value.min = null
       this.value.max = null
+      this.value.bool = null
     }
   }
 }

--- a/src/components/nodes-table/filter-options.vue
+++ b/src/components/nodes-table/filter-options.vue
@@ -1,0 +1,107 @@
+<template>
+  <v-menu
+    :value="show"
+    :close-on-content-click="false"
+    :offset-y="true"
+  >
+    <template v-slot:activator="{ on, attrs }">
+      <v-icon small v-on:click="showOptions()"
+        v-bind="attrs"
+        v-on="on"
+        title="Filter options..."
+      >
+        {{ hasFilter ? 'filter_list_alt' : 'filter_list' }}
+      </v-icon>
+    </template>
+    <v-card>
+      <v-icon small v-on:click="hideOptions()" right>close</v-icon>
+      <v-card-text>
+        <v-row v-if="value && value.type=='string'">
+          <v-col>
+            <v-text-field
+              ref="search"
+              label="Contains"
+              v-model="value.search"
+              clearable
+              @change="hideOptions()"
+              @show="$refs.search.$el.focus()"
+            ></v-text-field>
+          </v-col>
+        </v-row>
+        <v-row v-if="value && value.type=='number'">
+          <v-col>
+            <v-text-field type="number" label="Min" v-model="value.min" clearable></v-text-field>
+          </v-col>
+          <v-col>
+            <v-text-field type="number" label="Max" v-model="value.max" clearable></v-text-field>
+          </v-col>
+        </v-row>
+        <v-row v-if="value && value.type=='date'">
+          <v-col>
+            <v-text-field type="datetime-local" label="From" v-model="value.min" clearable></v-text-field>
+            <v-text-field type="datetime-local" label="Until" v-model="value.max" clearable></v-text-field>
+          </v-col>
+        </v-row>
+        <v-row v-if="value && (value.type=='string' || value.type=='number' || value.type=='boolean')">
+          <v-col>
+            <v-select
+              v-model="value.selections"
+              :items="items"
+              label="Selection"
+              clearable
+              chips
+              deletableChips
+              dense
+              multiple
+            ></v-select>
+          </v-col>
+        </v-row>
+      </v-card-text>
+      <v-card-actions>
+        <v-btn @click="clearFilter()">Clear</v-btn>
+        <v-btn color="primary" @click="hideOptions()">Ok</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-menu>
+</template>
+
+<script>
+export default {
+  props: {
+    value: {
+      type: Object,
+    },
+    items: {
+      type: Array,
+    }
+  },
+  data () {
+    return {
+      show: false,
+    }
+  },
+  computed: {
+    hasFilter () {
+      return this.value !== undefined && this.value !== null &&
+        ((this.value.search !== undefined && this.value.search !== null && this.value.search !== '')
+        || (this.value.selections !== undefined && this.value.selections !== null && this.value.selections.length > 0)
+        || (this.value.min !== undefined && this.value.min !== null)
+        || (this.value.max !== undefined && this.value.max !== null))
+    },
+  },
+  methods: {
+    showOptions() {
+      this.show = true
+    },
+    hideOptions() {
+      this.show = false
+    },
+    clearFilter () {
+      this.value.search = null
+      this.value.selections = []
+      this.value.min = null
+      this.value.max = null
+    }
+  }
+}
+</script>

--- a/src/components/nodes-table/index.vue
+++ b/src/components/nodes-table/index.vue
@@ -12,25 +12,16 @@
     class="elevation-1"
   >
     <template v-slot:top>
-      <v-btn
-        color="blue darken-1"
-        text
-        @click.native="resetFilter()"
+      <v-btn color="blue darken-1" text @click.native="resetFilter()"
         >Reset Filter</v-btn
       >
     </template>
     <template v-slot:header.node_id="{ header }">
-      <filter-options
-        v-model="filters.ids"
-        :items="ids"
-      ></filter-options>
+      <filter-options v-model="filters.ids" :items="ids"></filter-options>
       {{ header.text }}
     </template>
     <template v-slot:header.type="{ header }">
-      <filter-options
-        v-model="filters.types"
-        :items="types"
-      ></filter-options>
+      <filter-options v-model="filters.types" :items="types"></filter-options>
       {{ header.text }}
     </template>
     <template v-slot:header.product="{ header }">
@@ -41,10 +32,7 @@
       {{ header.text }}
     </template>
     <template v-slot:header.name="{ header }">
-      <filter-options
-        v-model="filters.names"
-        :items="names"
-      ></filter-options>
+      <filter-options v-model="filters.names" :items="names"></filter-options>
       {{ header.text }}
     </template>
     <template v-slot:header.loc="{ header }">
@@ -62,10 +50,7 @@
       {{ header.text }}
     </template>
     <template v-slot:header.status="{ header }">
-      <filter-options
-        v-model="filters.states"
-        :items="states"
-      ></filter-options>
+      <filter-options v-model="filters.states" :items="states"></filter-options>
       {{ header.text }}
     </template>
     <template v-slot:header.lastActive="{ header }">

--- a/src/components/nodes-table/index.vue
+++ b/src/components/nodes-table/index.vue
@@ -1,0 +1,108 @@
+<template>
+  <v-data-table
+    :headers="headers"
+    :items="tableNodes"
+    :footer-props="{
+      itemsPerPageOptions: [10, 20, 50, 100, -1]
+    }"
+    :options="{
+      itemsPerPage: 20
+    }"
+    item-key="node_id"
+    class="elevation-1"
+  >
+    <template v-slot:top>
+      <v-btn
+        color="blue darken-1"
+        text
+        @click.native="resetFilter()"
+        >Reset Filter</v-btn
+      >
+    </template>
+    <template v-slot:header.node_id="{ header }">
+      <filter-options
+        v-model="filters.ids"
+        :items="ids"
+      ></filter-options>
+      {{ header.text }}
+    </template>
+    <template v-slot:header.type="{ header }">
+      <filter-options
+        v-model="filters.types"
+        :items="types"
+      ></filter-options>
+      {{ header.text }}
+    </template>
+    <template v-slot:header.product="{ header }">
+      <filter-options
+        v-model="filters.products"
+        :items="products"
+      ></filter-options>
+      {{ header.text }}
+    </template>
+    <template v-slot:header.name="{ header }">
+      <filter-options
+        v-model="filters.names"
+        :items="names"
+      ></filter-options>
+      {{ header.text }}
+    </template>
+    <template v-slot:header.loc="{ header }">
+      <filter-options
+        v-model="filters.locations"
+        :items="locations"
+      ></filter-options>
+      {{ header.text }}
+    </template>
+    <template v-slot:header.secure="{ header }">
+      <filter-options
+        v-model="filters.secures"
+        :items="secures"
+      ></filter-options>
+      {{ header.text }}
+    </template>
+    <template v-slot:header.status="{ header }">
+      <filter-options
+        v-model="filters.states"
+        :items="states"
+      ></filter-options>
+      {{ header.text }}
+    </template>
+    <template v-slot:header.lastActive="{ header }">
+      <filter-options
+        v-model="filters.lastActives"
+        :items="lastActives"
+      ></filter-options>
+      {{ header.text }}
+    </template>
+    <template v-slot:item="{ item }">
+      <tr
+        :style="{
+          cursor: 'pointer',
+          background:
+            selectedNode === item ? $vuetify.theme.themes.light.accent : 'none'
+        }"
+        @click.stop="nodeSelected(item)"
+      >
+        <td>{{ item.node_id }}</td>
+        <td class="td-large">{{ item.type }}</td>
+        <td class="td-large" :title="productName(item)">
+          {{ productName(item) }}
+        </td>
+        <td>{{ item.name || '' }}</td>
+        <td>{{ item.loc || '' }}</td>
+        <td>{{ item.secure ? 'Yes' : 'No' }}</td>
+        <td class="td-medium">{{ item.status }}</td>
+        <td>
+          {{
+            item.lastActive
+              ? new Date(item.lastActive).toLocaleString()
+              : 'Never'
+          }}
+        </td>
+      </tr>
+    </template>
+  </v-data-table>
+</template>
+<script src="./nodes-table.js"></script>
+<style scoped src="./nodes-table.css"></style>

--- a/src/components/nodes-table/index.vue
+++ b/src/components/nodes-table/index.vue
@@ -5,9 +5,7 @@
     :footer-props="{
       itemsPerPageOptions: [10, 20, 50, 100, -1]
     }"
-    :options="{
-      itemsPerPage: 20
-    }"
+    :items-per-page.sync="nodeTableItems"
     item-key="node_id"
     class="elevation-1"
   >

--- a/src/components/nodes-table/nodes-table.css
+++ b/src/components/nodes-table/nodes-table.css
@@ -1,0 +1,26 @@
+.td-large {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow-x: hidden;
+  max-width: 20em;
+}
+
+.td-medium {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow-x: hidden;
+  max-width: 15em;
+}
+
+.td-small {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow-x: hidden;
+  max-width: 10em;
+}
+
+.v-chip {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow-x: hidden;
+}

--- a/src/components/nodes-table/nodes-table.js
+++ b/src/components/nodes-table/nodes-table.js
@@ -73,7 +73,6 @@ export default {
         .contains(['type'], this.filters.types ? this.filters.types.search : '')
         .contains(['name'], this.filters.names ? this.filters.names.search : '')
         .contains(['loc'], this.filters.locations ? this.filters.locations.search : '')
-        .contains(['secure'], this.filters.secures ? this.filters.secures.search : '')
         .contains(['status'], this.filters.states ? this.filters.states.search : '')
 
         .equalsAny('node_id', this.filters.ids ? (this.filters.ids.selections ? this.filters.ids.selections : []) : [])
@@ -81,8 +80,9 @@ export default {
         .equalsAny('product', this.filters.products ? (this.filters.products.selections ? this.filters.products.selections : []) : [])
         .equalsAny('name', this.filters.names ? (this.filters.names.selections ? this.filters.names.selections : []) : [])
         .equalsAny('loc', this.filters.locations ? (this.filters.locations.selections ? this.filters.locations.selections : []) : [])
-        .equalsAny('secure', this.filters.secures ? (this.filters.secures.selections ? this.filters.secures.selections : []) : [])
         .equalsAny('status', this.filters.states ? (this.filters.states.selections ? this.filters.states.selections : []) : [])
+
+        .equals('secure', this.filters.secures ? this.filters.secures.bool : null)
     },
     tableNodes () {
       return this.filteredNodes.nodes

--- a/src/components/nodes-table/nodes-table.js
+++ b/src/components/nodes-table/nodes-table.js
@@ -1,5 +1,3 @@
-'esversion: 6'
-
 import { NodeCollection } from '@/modules/NodeCollection'
 import filterOptions from '@/components/nodes-table/filter-options.vue'
 

--- a/src/components/nodes-table/nodes-table.js
+++ b/src/components/nodes-table/nodes-table.js
@@ -1,4 +1,4 @@
-'esversion: 6';
+'esversion: 6'
 
 import { NodeCollection } from '@/modules/NodeCollection'
 import filterOptions from '@/components/nodes-table/filter-options.vue'
@@ -26,7 +26,7 @@ export default {
     ]
   }),
   methods: {
-    initFilters() {
+    initFilters () {
       return {
         ids: { type: 'number' },
         types: { type: 'string' },
@@ -38,7 +38,7 @@ export default {
         lastActives: { type: 'date' }
       }
     },
-    resetFilter() {
+    resetFilter () {
       this.filters = this.initFilters()
     },
     nodeSelected (node) {
@@ -57,13 +57,13 @@ export default {
     nodeCollection () {
       return new NodeCollection(this.nodes)
     },
-    relevantNodes() {
+    relevantNodes () {
       return this.nodeCollection
         .filter('failed', failed => {
           return (this.showHidden ? true : !failed)
         })
     },
-    filteredNodes() {
+    filteredNodes () {
       return this.relevantNodes
         .betweenNumber('node_id', this.filters.ids ? this.filters.ids.min : null, this.filters.ids ? this.filters.ids.max : null)
         .betweenDate('lastActive', this.filters.lastActives ? this.filters.lastActives.min : null, this.filters.lastActives ? this.filters.lastActives.max : null)
@@ -89,19 +89,19 @@ export default {
     tableNodes () {
       return this.filteredNodes.nodes
     },
-    ids() {
+    ids () {
       return this.relevantNodes.values('node_id')
     },
-    products() {
+    products () {
       return this.relevantNodes.values('product')
     },
-    names() {
+    names () {
       return this.relevantNodes.values('name')
     },
     locations () {
       return this.relevantNodes.values('loc')
     },
-    secures() {
+    secures () {
       return [undefined, false, true]
     },
     states () {
@@ -110,7 +110,7 @@ export default {
     types () {
       return this.relevantNodes.values('type')
     },
-    lastActives() {
+    lastActives () {
       return this.relevantNodes.values('lastActive')
     }
   }

--- a/src/components/nodes-table/nodes-table.js
+++ b/src/components/nodes-table/nodes-table.js
@@ -10,6 +10,7 @@ export default {
     filterOptions
   },
   data: () => ({
+    nodeTableItems: 10,
     selectedNode: undefined,
     filters: {},
     headers: [
@@ -50,6 +51,13 @@ export default {
   },
   mounted () {
     this.filters = this.initFilters()
+    const itemsPerPage = parseInt(localStorage.getItem('nodes_itemsPerPage'))
+    this.nodeTableItems = !isNaN(itemsPerPage) ? itemsPerPage : 10
+  },
+  watch: {
+    nodeTableItems (val) {
+      localStorage.setItem('nodes_itemsPerPage', val)
+    }
   },
   computed: {
     nodeCollection () {

--- a/src/components/nodes-table/nodes-table.js
+++ b/src/components/nodes-table/nodes-table.js
@@ -1,0 +1,117 @@
+'esversion: 6';
+
+import { NodeCollection } from '@/modules/NodeCollection'
+import filterOptions from '@/components/nodes-table/filter-options.vue'
+
+export default {
+  props: {
+    nodes: Array,
+    showHidden: Boolean
+  },
+  components: {
+    filterOptions
+  },
+  data: () => ({
+    selectedNode: undefined,
+    filters: {},
+    headers: [
+      { text: 'ID', value: 'node_id' },
+      { text: 'Type', value: 'type' },
+      { text: 'Product', value: 'product' },
+      { text: 'Name', value: 'name' },
+      { text: 'Location', value: 'loc' },
+      { text: 'Secure', value: 'secure' },
+      { text: 'Status', value: 'status' },
+      { text: 'Last Active', value: 'lastActive' }
+    ]
+  }),
+  methods: {
+    initFilters() {
+      return {
+        ids: { type: 'number' },
+        types: { type: 'string' },
+        products: { type: 'string' },
+        names: { type: 'string' },
+        locations: { type: 'string' },
+        secures: { type: 'boolean' },
+        states: { type: 'string' },
+        lastActives: { type: 'date' }
+      }
+    },
+    resetFilter() {
+      this.filters = this.initFilters()
+    },
+    nodeSelected (node) {
+      this.selectedNode = node
+      this.$emit('node-selected', { node })
+    },
+    productName (node) {
+      const manufacturer = node.manufacturer ? ` (${node.manufacturer})` : ''
+      return node.ready ? `${node.product}${manufacturer}` : ''
+    }
+  },
+  mounted: function () {
+    this.filters = this.initFilters()
+  },
+  computed: {
+    nodeCollection () {
+      return new NodeCollection(this.nodes)
+    },
+    relevantNodes() {
+      return this.nodeCollection
+        .filter('failed', failed => {
+          return (this.showHidden ? true : !failed)
+        })
+    },
+    filteredNodes() {
+      return this.relevantNodes
+        .betweenNumber('node_id', this.filters.ids ? this.filters.ids.min : null, this.filters.ids ? this.filters.ids.max : null)
+        .betweenDate('lastActive', this.filters.lastActives ? this.filters.lastActives.min : null, this.filters.lastActives ? this.filters.lastActives.max : null)
+
+        .contains(
+          ['product', 'manufacturer'],
+          this.filters.products ? this.filters.products.search : ''
+        )
+        .contains(['type'], this.filters.types ? this.filters.types.search : '')
+        .contains(['name'], this.filters.names ? this.filters.names.search : '')
+        .contains(['loc'], this.filters.locations ? this.filters.locations.search : '')
+        .contains(['secure'], this.filters.secures ? this.filters.secures.search : '')
+        .contains(['status'], this.filters.states ? this.filters.states.search : '')
+
+        .equalsAny('node_id', this.filters.ids ? (this.filters.ids.selections ? this.filters.ids.selections : []) : [])
+        .equalsAny('type', this.filters.types ? (this.filters.types.selections ? this.filters.types.selections : []) : [])
+        .equalsAny('product', this.filters.products ? (this.filters.products.selections ? this.filters.products.selections : []) : [])
+        .equalsAny('name', this.filters.names ? (this.filters.names.selections ? this.filters.names.selections : []) : [])
+        .equalsAny('loc', this.filters.locations ? (this.filters.locations.selections ? this.filters.locations.selections : []) : [])
+        .equalsAny('secure', this.filters.secures ? (this.filters.secures.selections ? this.filters.secures.selections : []) : [])
+        .equalsAny('status', this.filters.states ? (this.filters.states.selections ? this.filters.states.selections : []) : [])
+    },
+    tableNodes () {
+      return this.filteredNodes.nodes
+    },
+    ids() {
+      return this.relevantNodes.values('node_id')
+    },
+    products() {
+      return this.relevantNodes.values('product')
+    },
+    names() {
+      return this.relevantNodes.values('name')
+    },
+    locations () {
+      return this.relevantNodes.values('loc')
+    },
+    secures() {
+      return [undefined, false, true]
+    },
+    states () {
+      return this.relevantNodes.values('status')
+    },
+    types () {
+      return this.relevantNodes.values('type')
+    },
+    lastActives() {
+      return this.relevantNodes.values('lastActive')
+    }
+  }
+}

--- a/src/components/nodes-table/nodes-table.js
+++ b/src/components/nodes-table/nodes-table.js
@@ -48,7 +48,7 @@ export default {
       return node.ready ? `${node.product}${manufacturer}` : ''
     }
   },
-  mounted: function () {
+  mounted () {
     this.filters = this.initFilters()
   },
   computed: {
@@ -56,15 +56,22 @@ export default {
       return new NodeCollection(this.nodes)
     },
     relevantNodes () {
-      return this.nodeCollection
-        .filter('failed', failed => {
-          return (this.showHidden ? true : !failed)
-        })
+      return this.nodeCollection.filter('failed', failed => {
+        return this.showHidden ? true : !failed
+      })
     },
     filteredNodes () {
       return this.relevantNodes
-        .betweenNumber('node_id', this.filters.ids ? this.filters.ids.min : null, this.filters.ids ? this.filters.ids.max : null)
-        .betweenDate('lastActive', this.filters.lastActives ? this.filters.lastActives.min : null, this.filters.lastActives ? this.filters.lastActives.max : null)
+        .betweenNumber(
+          'node_id',
+          this.filters.ids ? this.filters.ids.min : null,
+          this.filters.ids ? this.filters.ids.max : null
+        )
+        .betweenDate(
+          'lastActive',
+          this.filters.lastActives ? this.filters.lastActives.min : null,
+          this.filters.lastActives ? this.filters.lastActives.max : null
+        )
 
         .contains(
           ['product', 'manufacturer'],
@@ -72,17 +79,68 @@ export default {
         )
         .contains(['type'], this.filters.types ? this.filters.types.search : '')
         .contains(['name'], this.filters.names ? this.filters.names.search : '')
-        .contains(['loc'], this.filters.locations ? this.filters.locations.search : '')
-        .contains(['status'], this.filters.states ? this.filters.states.search : '')
+        .contains(
+          ['loc'],
+          this.filters.locations ? this.filters.locations.search : ''
+        )
+        .contains(
+          ['status'],
+          this.filters.states ? this.filters.states.search : ''
+        )
 
-        .equalsAny('node_id', this.filters.ids ? (this.filters.ids.selections ? this.filters.ids.selections : []) : [])
-        .equalsAny('type', this.filters.types ? (this.filters.types.selections ? this.filters.types.selections : []) : [])
-        .equalsAny('product', this.filters.products ? (this.filters.products.selections ? this.filters.products.selections : []) : [])
-        .equalsAny('name', this.filters.names ? (this.filters.names.selections ? this.filters.names.selections : []) : [])
-        .equalsAny('loc', this.filters.locations ? (this.filters.locations.selections ? this.filters.locations.selections : []) : [])
-        .equalsAny('status', this.filters.states ? (this.filters.states.selections ? this.filters.states.selections : []) : [])
+        .equalsAny(
+          'node_id',
+          this.filters.ids
+            ? this.filters.ids.selections
+              ? this.filters.ids.selections
+              : []
+            : []
+        )
+        .equalsAny(
+          'type',
+          this.filters.types
+            ? this.filters.types.selections
+              ? this.filters.types.selections
+              : []
+            : []
+        )
+        .equalsAny(
+          'product',
+          this.filters.products
+            ? this.filters.products.selections
+              ? this.filters.products.selections
+              : []
+            : []
+        )
+        .equalsAny(
+          'name',
+          this.filters.names
+            ? this.filters.names.selections
+              ? this.filters.names.selections
+              : []
+            : []
+        )
+        .equalsAny(
+          'loc',
+          this.filters.locations
+            ? this.filters.locations.selections
+              ? this.filters.locations.selections
+              : []
+            : []
+        )
+        .equalsAny(
+          'status',
+          this.filters.states
+            ? this.filters.states.selections
+              ? this.filters.states.selections
+              : []
+            : []
+        )
 
-        .equals('secure', this.filters.secures ? this.filters.secures.bool : null)
+        .equals(
+          'secure',
+          this.filters.secures ? this.filters.secures.bool : null
+        )
     },
     tableNodes () {
       return this.filteredNodes.nodes

--- a/src/modules/NodeCollection.js
+++ b/src/modules/NodeCollection.js
@@ -1,0 +1,77 @@
+export class NodeCollection {
+  constructor (nodes) {
+    this.nodes = nodes
+  }
+
+  _strValue (str, caseSensitive) {
+    return caseSensitive ? `${str}` : `${str}`.toLowerCase()
+  }
+
+  _createStringFilter (filterValue, caseSensitive) {
+    if (filterValue === undefined || filterValue === null) {
+      filterValue = ''
+    }
+    const strFilter = this._strValue(filterValue, caseSensitive)
+    return value => this._strValue(value, caseSensitive).indexOf(strFilter) >= 0
+  }
+
+  _filterByProps (node, properties, filter) {
+    const mergedProps = [properties].reduce(
+      (merged, prop) => merged.concat(prop),
+      []
+    )
+    return mergedProps.find(prop => filter(node[prop]))
+  }
+
+  filter (properties, filter) {
+    const filtered = this.nodes.filter(node =>
+      this._filterByProps(node, properties, filter)
+    )
+    return new NodeCollection(filtered)
+  }
+
+  contains (properties, value, caseSensitive = false) {
+    return this.filter(
+      properties,
+      this._createStringFilter(value, caseSensitive)
+    )
+  }
+
+  equals (properties, value) {
+    return this.filter(properties, nodeValue => value === nodeValue)
+  }
+
+  betweenNumber(properties, minValue, maxValue) {
+    return this.filter(properties, nodeValue =>
+      (minValue === undefined || minValue === null || minValue === '' || minValue <= nodeValue)
+      && (maxValue === undefined || maxValue === null || maxValue === '' || maxValue >= nodeValue)
+    )
+  }
+
+  betweenDate(properties, minValue, maxValue) {
+    return this.filter(properties, nodeValue =>
+      (minValue === undefined || minValue === null || minValue === '' || new Date(minValue) <= nodeValue)
+      && (maxValue === undefined || maxValue === null || maxValue === '' || new Date(maxValue) >= nodeValue)
+    )
+  }
+
+  equalsAny (properties, values) {
+    return this.filter(
+      properties,
+      nodeValue => values.length === 0 || values.indexOf(nodeValue) >= 0
+    )
+  }
+
+  values (property) {
+    const uniqueMap = {}
+    this.nodes.forEach(node => {
+      const strVal = this._strValue(node[property])
+      uniqueMap[strVal] = uniqueMap[strVal] || node[property]
+    })
+    return Object.keys(uniqueMap)
+      .sort()
+      .map(key => uniqueMap[key])
+  }
+}
+
+export default NodeCollection

--- a/src/modules/NodeCollection.js
+++ b/src/modules/NodeCollection.js
@@ -3,12 +3,16 @@ export class NodeCollection {
     this.nodes = nodes
   }
 
+  _isUndefined (value) {
+    return value === undefined || value === null || value === ''
+  }
+
   _strValue (str, caseSensitive) {
     return caseSensitive ? `${str}` : `${str}`.toLowerCase()
   }
 
   _createStringFilter (filterValue, caseSensitive) {
-    if (filterValue === undefined || filterValue === null) {
+    if (this._isUndefined(filterValue)) {
       filterValue = ''
     }
     const strFilter = this._strValue(filterValue, caseSensitive)
@@ -43,15 +47,15 @@ export class NodeCollection {
 
   betweenNumber (properties, minValue, maxValue) {
     return this.filter(properties, nodeValue =>
-      (minValue === undefined || minValue === null || minValue === '' || minValue <= nodeValue) &&
-      (maxValue === undefined || maxValue === null || maxValue === '' || maxValue >= nodeValue)
+      (this._isUndefined(minValue) || minValue <= nodeValue) &&
+      (this._isUndefined(maxValue) || maxValue >= nodeValue)
     )
   }
 
   betweenDate (properties, minValue, maxValue) {
     return this.filter(properties, nodeValue =>
-      (minValue === undefined || minValue === null || minValue === '' || new Date(minValue) <= nodeValue) &&
-      (maxValue === undefined || maxValue === null || maxValue === '' || new Date(maxValue) >= nodeValue)
+      (this._isUndefined(minValue) || new Date(minValue).getTime() <= nodeValue) &&
+      (this._isUndefined(maxValue) || new Date(maxValue).getTime() >= nodeValue)
     )
   }
 

--- a/src/modules/NodeCollection.js
+++ b/src/modules/NodeCollection.js
@@ -53,10 +53,11 @@ export class NodeCollection {
   }
 
   betweenDate (properties, minValue, maxValue) {
-    return this.filter(properties, nodeValue =>
-      (this._isUndefined(minValue) || new Date(minValue).getTime() <= nodeValue) &&
-      (this._isUndefined(maxValue) || new Date(maxValue).getTime() >= nodeValue)
-    )
+    return this.filter(properties, nodeValue => {
+      const nodeValueTime = new Date(nodeValue).getTime()
+      return (this._isUndefined(minValue) || new Date(minValue).getTime() <= nodeValueTime) &&
+        (this._isUndefined(maxValue) || new Date(maxValue).getTime() >= nodeValueTime)
+    })
   }
 
   equalsAny (properties, values) {

--- a/src/modules/NodeCollection.js
+++ b/src/modules/NodeCollection.js
@@ -42,7 +42,7 @@ export class NodeCollection {
   }
 
   equals (properties, value) {
-    return this.filter(properties, nodeValue => value === nodeValue)
+    return this.filter(properties, nodeValue => this._isUndefined(value) || value === nodeValue)
   }
 
   betweenNumber (properties, minValue, maxValue) {

--- a/src/modules/NodeCollection.js
+++ b/src/modules/NodeCollection.js
@@ -42,21 +42,30 @@ export class NodeCollection {
   }
 
   equals (properties, value) {
-    return this.filter(properties, nodeValue => this._isUndefined(value) || value === nodeValue)
+    return this.filter(
+      properties,
+      nodeValue => this._isUndefined(value) || value === nodeValue
+    )
   }
 
   betweenNumber (properties, minValue, maxValue) {
-    return this.filter(properties, nodeValue =>
-      (this._isUndefined(minValue) || minValue <= nodeValue) &&
-      (this._isUndefined(maxValue) || maxValue >= nodeValue)
+    return this.filter(
+      properties,
+      nodeValue =>
+        (this._isUndefined(minValue) || minValue <= nodeValue) &&
+        (this._isUndefined(maxValue) || maxValue >= nodeValue)
     )
   }
 
   betweenDate (properties, minValue, maxValue) {
     return this.filter(properties, nodeValue => {
       const nodeValueTime = new Date(nodeValue).getTime()
-      return (this._isUndefined(minValue) || new Date(minValue).getTime() <= nodeValueTime) &&
-        (this._isUndefined(maxValue) || new Date(maxValue).getTime() >= nodeValueTime)
+      return (
+        (this._isUndefined(minValue) ||
+          new Date(minValue).getTime() <= nodeValueTime) &&
+        (this._isUndefined(maxValue) ||
+          new Date(maxValue).getTime() >= nodeValueTime)
+      )
     })
   }
 

--- a/src/modules/NodeCollection.js
+++ b/src/modules/NodeCollection.js
@@ -41,17 +41,17 @@ export class NodeCollection {
     return this.filter(properties, nodeValue => value === nodeValue)
   }
 
-  betweenNumber(properties, minValue, maxValue) {
+  betweenNumber (properties, minValue, maxValue) {
     return this.filter(properties, nodeValue =>
-      (minValue === undefined || minValue === null || minValue === '' || minValue <= nodeValue)
-      && (maxValue === undefined || maxValue === null || maxValue === '' || maxValue >= nodeValue)
+      (minValue === undefined || minValue === null || minValue === '' || minValue <= nodeValue) &&
+      (maxValue === undefined || maxValue === null || maxValue === '' || maxValue >= nodeValue)
     )
   }
 
-  betweenDate(properties, minValue, maxValue) {
+  betweenDate (properties, minValue, maxValue) {
     return this.filter(properties, nodeValue =>
-      (minValue === undefined || minValue === null || minValue === '' || new Date(minValue) <= nodeValue)
-      && (maxValue === undefined || maxValue === null || maxValue === '' || new Date(maxValue) >= nodeValue)
+      (minValue === undefined || minValue === null || minValue === '' || new Date(minValue) <= nodeValue) &&
+      (maxValue === undefined || maxValue === null || maxValue === '' || new Date(maxValue) >= nodeValue)
     )
   }
 

--- a/src/modules/NodeCollection.test.js
+++ b/src/modules/NodeCollection.test.js
@@ -197,9 +197,7 @@ describe('NodeCollection', () => {
         { id: 30, sample: 30 }
       ])
       const filtered = collection.betweenNumber('id', 15, 25)
-      chai.expect(filtered.nodes).to.eql([
-        { id: 20, sample: 20 }
-      ])
+      chai.expect(filtered.nodes).to.eql([{ id: 20, sample: 20 }])
     })
   })
   describe('#betweenDate', () => {
@@ -209,7 +207,11 @@ describe('NodeCollection', () => {
         { id: 20, lastActive: new Date(2020, 11, 10, 0, 0) },
         { id: 30, lastActive: new Date(2020, 11, 11, 0, 0) }
       ])
-      const filtered = collection.betweenDate('lastActive', undefined, undefined)
+      const filtered = collection.betweenDate(
+        'lastActive',
+        undefined,
+        undefined
+      )
       chai.expect(filtered.nodes).to.eql([
         { id: 10, lastActive: new Date(2020, 11, 9, 0, 0) },
         { id: 20, lastActive: new Date(2020, 11, 10, 0, 0) },
@@ -235,7 +237,11 @@ describe('NodeCollection', () => {
         { id: 20, lastActive: new Date(2020, 11, 10, 0, 0) },
         { id: 30, lastActive: new Date(2020, 11, 11, 0, 0) }
       ])
-      const filtered = collection.betweenDate('lastActive', new Date(2020, 11, 10, 0, 0), null)
+      const filtered = collection.betweenDate(
+        'lastActive',
+        new Date(2020, 11, 10, 0, 0),
+        null
+      )
       chai.expect(filtered.nodes).to.eql([
         { id: 20, lastActive: new Date(2020, 11, 10, 0, 0) },
         { id: 30, lastActive: new Date(2020, 11, 11, 0, 0) }
@@ -247,7 +253,11 @@ describe('NodeCollection', () => {
         { id: 20, lastActive: new Date(2020, 11, 10, 0, 0) },
         { id: 30, lastActive: new Date(2020, 11, 11, 0, 0) }
       ])
-      const filtered = collection.betweenDate('lastActive', null, new Date(2020, 11, 10, 0, 0))
+      const filtered = collection.betweenDate(
+        'lastActive',
+        null,
+        new Date(2020, 11, 10, 0, 0)
+      )
       chai.expect(filtered.nodes).to.eql([
         { id: 10, lastActive: new Date(2020, 11, 9, 0, 0) },
         { id: 20, lastActive: new Date(2020, 11, 10, 0, 0) }
@@ -259,10 +269,14 @@ describe('NodeCollection', () => {
         { id: 20, lastActive: new Date(2020, 11, 10, 0, 0) },
         { id: 30, lastActive: new Date(2020, 11, 11, 0, 0) }
       ])
-      const filtered = collection.betweenDate('lastActive', new Date(2020, 11, 9, 12, 0), new Date(2020, 11, 10, 12, 0))
-      chai.expect(filtered.nodes).to.eql([
-        { id: 20, lastActive: new Date(2020, 11, 10, 0, 0) }
-      ])
+      const filtered = collection.betweenDate(
+        'lastActive',
+        new Date(2020, 11, 9, 12, 0),
+        new Date(2020, 11, 10, 12, 0)
+      )
+      chai
+        .expect(filtered.nodes)
+        .to.eql([{ id: 20, lastActive: new Date(2020, 11, 10, 0, 0) }])
     })
   })
   describe('#values', () => {

--- a/src/modules/NodeCollection.test.js
+++ b/src/modules/NodeCollection.test.js
@@ -1,0 +1,281 @@
+import chai from 'chai'
+import { NodeCollection } from './NodeCollection'
+
+describe('NodeCollection', () => {
+  describe('#constructor', () => {
+    it('uses the nodes passed in as the collection nodes', () => {
+      const collection = new NodeCollection([{ id: 1 }])
+      chai.expect(collection.nodes).to.eql([{ id: 1 }])
+    })
+  })
+  describe('#filter', () => {
+    const isOdd = num => num % 2
+    it('returns nodes with the property matching the filter', () => {
+      const collection = new NodeCollection([
+        { id: 1 },
+        { id: 2 },
+        { id: 3 },
+        { id: 4 }
+      ])
+      const filtered = collection.filter('id', isOdd)
+      chai.expect(filtered.nodes).to.eql([{ id: 1 }, { id: 3 }])
+    })
+    it('returns nodes with any of the properties matching the filter', () => {
+      const collection = new NodeCollection([
+        { id: 1, value: 2 },
+        { id: 2, value: 1 },
+        { id: 3, value: 2 },
+        { id: 4, value: 2 }
+      ])
+      const filtered = collection.filter(['id', 'value'], isOdd)
+      chai.expect(filtered.nodes).to.eql([
+        { id: 1, value: 2 },
+        { id: 2, value: 1 },
+        { id: 3, value: 2 }
+      ])
+    })
+  })
+  describe('#contains', () => {
+    const stringCollection = new NodeCollection([
+      { id: 'pippo' },
+      { id: 'paRanza' },
+      { id: 'PipPo' },
+      { id: 'Ames' }
+    ])
+
+    it('returns nodes with the properties containing the value', () => {
+      const collection = new NodeCollection([
+        { id: 100 },
+        { id: '210' },
+        { id: 20 },
+        { id: '300' }
+      ])
+      const filtered = collection.contains('id', '10')
+      chai.expect(filtered.nodes).to.eql([{ id: 100 }, { id: '210' }])
+    })
+    it('matches values over multiple properties', () => {
+      const collection = new NodeCollection([
+        { id: 100, name: 'sample' },
+        { id: '210', name: 'trinity' },
+        { id: 20, name: '10 packs' },
+        { id: '300', name: 'fazuoli' }
+      ])
+      const filtered = collection.contains(['id', 'name'], '10')
+      chai.expect(filtered.nodes).to.eql([
+        { id: 100, name: 'sample' },
+        { id: '210', name: 'trinity' },
+        { id: 20, name: '10 packs' }
+      ])
+    })
+    it('is case insensitive by default', () => {
+      const filtered = stringCollection.contains('id', 'piPPo')
+      chai.expect(filtered.nodes).to.eql([{ id: 'pippo' }, { id: 'PipPo' }])
+    })
+    it('accepts a case sensitive flag', () => {
+      const filtered = stringCollection.contains('id', 'PipPo', true)
+      chai.expect(filtered.nodes).to.eql([{ id: 'PipPo' }])
+    })
+  })
+  describe('#equals', () => {
+    it('returns nodes with the properties with equal value', () => {
+      const collection = new NodeCollection([
+        { id: 10 },
+        { id: '10' },
+        { id: 20 },
+        { id: '20' }
+      ])
+      const filtered = collection.equals('id', 10)
+      chai.expect(filtered.nodes).to.eql([{ id: 10 }])
+    })
+    it('works over multiple properties', () => {
+      const collection = new NodeCollection([
+        { id: 10, sample: '20' },
+        { id: '10', sample: 30 },
+        { id: 20, sample: '10' },
+        { id: '20', sample: 10 }
+      ])
+      const filtered = collection.equals(['id', 'sample'], 10)
+      chai.expect(filtered.nodes).to.eql([
+        { id: 10, sample: '20' },
+        { id: '20', sample: 10 }
+      ])
+    })
+  })
+  describe('#equalsAny', () => {
+    it('returns all nodes when values has no elements', () => {
+      const collection = new NodeCollection([
+        { id: 10 },
+        { id: '10' },
+        { id: 20 },
+        { id: '20' }
+      ])
+      const filtered = collection.equalsAny('id', [])
+      chai
+        .expect(filtered.nodes)
+        .to.eql([{ id: 10 }, { id: '10' }, { id: 20 }, { id: '20' }])
+    })
+    it('returns nodes with the properties equal to any of the values', () => {
+      const collection = new NodeCollection([
+        { id: 10 },
+        { id: '10' },
+        { id: 20 },
+        { id: '20' }
+      ])
+      const filtered = collection.equalsAny('id', [10, '20'])
+      chai.expect(filtered.nodes).to.eql([{ id: 10 }, { id: '20' }])
+    })
+    it('works over multiple properties', () => {
+      const collection = new NodeCollection([
+        { id: 10, sample: 20 },
+        { id: '10', sample: '20' },
+        { id: 20, sample: '10' },
+        { id: '20', sample: 'zdub' }
+      ])
+      const filtered = collection.equalsAny(['id', 'sample'], [10, '20'])
+      chai.expect(filtered.nodes).to.eql([
+        { id: 10, sample: 20 },
+        { id: '10', sample: '20' },
+        { id: '20', sample: 'zdub' }
+      ])
+    })
+  })
+  describe('#betweenNumber', () => {
+    it('returns all values if min/max are undefined', () => {
+      const collection = new NodeCollection([
+        { id: 10, sample: 10 },
+        { id: 20, sample: 20 },
+        { id: 30, sample: 30 }
+      ])
+      const filtered = collection.betweenNumber('id', undefined, undefined)
+      chai.expect(filtered.nodes).to.eql([
+        { id: 10, sample: 10 },
+        { id: 20, sample: 20 },
+        { id: 30, sample: 30 }
+      ])
+    })
+    it('returns all values if min/max are null', () => {
+      const collection = new NodeCollection([
+        { id: 10, sample: 10 },
+        { id: 20, sample: 20 },
+        { id: 30, sample: 30 }
+      ])
+      const filtered = collection.betweenNumber('id', null, null)
+      chai.expect(filtered.nodes).to.eql([
+        { id: 10, sample: 10 },
+        { id: 20, sample: 20 },
+        { id: 30, sample: 30 }
+      ])
+    })
+    it('returns all values that are greater or equal a min value', () => {
+      const collection = new NodeCollection([
+        { id: 10, sample: 10 },
+        { id: 20, sample: 20 },
+        { id: 30, sample: 30 }
+      ])
+      const filtered = collection.betweenNumber('id', 20, null)
+      chai.expect(filtered.nodes).to.eql([
+        { id: 20, sample: 20 },
+        { id: 30, sample: 30 }
+      ])
+    })
+    it('returns all values that are less than or equal a max value', () => {
+      const collection = new NodeCollection([
+        { id: 10, sample: 10 },
+        { id: 20, sample: 20 },
+        { id: 30, sample: 30 }
+      ])
+      const filtered = collection.betweenNumber('id', null, 20)
+      chai.expect(filtered.nodes).to.eql([
+        { id: 10, sample: 10 },
+        { id: 20, sample: 20 }
+      ])
+    })
+    it('returns all values that between or equal a min and a max value', () => {
+      const collection = new NodeCollection([
+        { id: 10, sample: 10 },
+        { id: 20, sample: 20 },
+        { id: 30, sample: 30 }
+      ])
+      const filtered = collection.betweenNumber('id', 15, 25)
+      chai.expect(filtered.nodes).to.eql([
+        { id: 20, sample: 20 }
+      ])
+    })
+  })
+  describe('#betweenDate', () => {
+    it('returns all date values if min/max are undefined', () => {
+      const collection = new NodeCollection([
+        { id: 10, lastActive: new Date(2020, 11, 9, 0, 0) },
+        { id: 20, lastActive: new Date(2020, 11, 10, 0, 0) },
+        { id: 30, lastActive: new Date(2020, 11, 11, 0, 0) }
+      ])
+      const filtered = collection.betweenDate('lastActive', undefined, undefined)
+      chai.expect(filtered.nodes).to.eql([
+        { id: 10, lastActive: new Date(2020, 11, 9, 0, 0) },
+        { id: 20, lastActive: new Date(2020, 11, 10, 0, 0) },
+        { id: 30, lastActive: new Date(2020, 11, 11, 0, 0) }
+      ])
+    })
+    it('returns all date values if min/max are null', () => {
+      const collection = new NodeCollection([
+        { id: 10, lastActive: new Date(2020, 11, 9, 0, 0) },
+        { id: 20, lastActive: new Date(2020, 11, 10, 0, 0) },
+        { id: 30, lastActive: new Date(2020, 11, 11, 0, 0) }
+      ])
+      const filtered = collection.betweenDate('lastActive', null, null)
+      chai.expect(filtered.nodes).to.eql([
+        { id: 10, lastActive: new Date(2020, 11, 9, 0, 0) },
+        { id: 20, lastActive: new Date(2020, 11, 10, 0, 0) },
+        { id: 30, lastActive: new Date(2020, 11, 11, 0, 0) }
+      ])
+    })
+    it('returns all date values that are greater or equal a min date value', () => {
+      const collection = new NodeCollection([
+        { id: 10, lastActive: new Date(2020, 11, 9, 0, 0) },
+        { id: 20, lastActive: new Date(2020, 11, 10, 0, 0) },
+        { id: 30, lastActive: new Date(2020, 11, 11, 0, 0) }
+      ])
+      const filtered = collection.betweenDate('lastActive', new Date(2020, 11, 10, 0, 0), null)
+      chai.expect(filtered.nodes).to.eql([
+        { id: 20, lastActive: new Date(2020, 11, 10, 0, 0) },
+        { id: 30, lastActive: new Date(2020, 11, 11, 0, 0) }
+      ])
+    })
+    it('returns all date values that are less than or equal a max date value', () => {
+      const collection = new NodeCollection([
+        { id: 10, lastActive: new Date(2020, 11, 9, 0, 0) },
+        { id: 20, lastActive: new Date(2020, 11, 10, 0, 0) },
+        { id: 30, lastActive: new Date(2020, 11, 11, 0, 0) }
+      ])
+      const filtered = collection.betweenDate('lastActive', null, new Date(2020, 11, 10, 0, 0))
+      chai.expect(filtered.nodes).to.eql([
+        { id: 10, lastActive: new Date(2020, 11, 9, 0, 0) },
+        { id: 20, lastActive: new Date(2020, 11, 10, 0, 0) }
+      ])
+    })
+    it('returns all date values that between or equal a min and a max date value', () => {
+      const collection = new NodeCollection([
+        { id: 10, lastActive: new Date(2020, 11, 9, 0, 0) },
+        { id: 20, lastActive: new Date(2020, 11, 10, 0, 0) },
+        { id: 30, lastActive: new Date(2020, 11, 11, 0, 0) }
+      ])
+      const filtered = collection.betweenDate('lastActive', new Date(2020, 11, 9, 12, 0), new Date(2020, 11, 10, 12, 0))
+      chai.expect(filtered.nodes).to.eql([
+        { id: 20, lastActive: new Date(2020, 11, 10, 0, 0) }
+      ])
+    })
+  })
+  describe('#values', () => {
+    it('returns a sorted list of unique values for a property - case ignored', () => {
+      const collection = new NodeCollection([
+        { name: 'Giacomo' },
+        { name: 'GiaCOMO' },
+        { name: 'Birretta' },
+        { name: 10 },
+        { name: 'giacomo' },
+        { name: 10 }
+      ])
+      chai.expect(collection.values('name')).to.eql([10, 'Birretta', 'Giacomo'])
+    })
+  })
+})


### PR DESCRIPTION
This PR is a merged and improved version of #582 and #800 and adds the possibility to filter nodes by their column values.

Filtering can done by the following ways:
* Search for a sub-string
* Select from a list of values
* Set min/max number values
* Set min/max date values

**Screenshots:**

Icons have been added to activate the filter options and to indicate a filtered column:
![image](https://user-images.githubusercontent.com/207989/98609108-e4222000-22ec-11eb-9de8-5e6a2983af1d.png)

Example of a substring and list selection filter:
![image](https://user-images.githubusercontent.com/207989/98609241-1cc1f980-22ed-11eb-9422-88e43703ac61.png)

Example of min/max number value filter:
![image](https://user-images.githubusercontent.com/207989/98609369-67437600-22ed-11eb-8ad0-cb562612cb53.png)

Example of min/max date value filter:
![image](https://user-images.githubusercontent.com/207989/98609441-8c37e900-22ed-11eb-8b1e-c937a0d1cd78.png)
